### PR TITLE
Create impact indicator summary pages 

### DIFF
--- a/app/(protected)/impactindicators/[id]/page.tsx
+++ b/app/(protected)/impactindicators/[id]/page.tsx
@@ -6,7 +6,7 @@ import SetDateRange from '@/components/date-filtering/set-date-range';
 export default async function IndicatorUpdatesPage({
   params,
 }: {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
   const supabase = await createClient();

--- a/app/(protected)/impactindicators/[id]/page.tsx
+++ b/app/(protected)/impactindicators/[id]/page.tsx
@@ -1,0 +1,41 @@
+import IndicatorUpdates from '@/components/impact-indicators/indicator-updates';
+import Breadcrumbs from '@/components/ui/breadcrumbs';
+import FeatureCard from '@/components/ui/feature-card';
+import { createClient } from '@/utils/supabase/server';
+
+export default async function IndicatorUpdatesPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('impact_indicators')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (error) {
+    return (
+      <FeatureCard>
+        <div className='flex flex-col gap-2'>
+          Error loading impact indicator: {(error as Error).message}
+        </div>
+      </FeatureCard>
+    );
+  }
+
+  return (
+    <div className='flex flex-col gap-8'>
+      <Breadcrumbs />
+      <div className='flex flex-col gap-2'>
+        <h3 className='font-semibold tracking-wide text-muted-foreground'>
+          Impact Indicator {data.indicator_code}
+        </h3>
+        <h2 className='text-2xl font-semibold'>{data.indicator_title}</h2>
+      </div>
+      <IndicatorUpdates />
+    </div>
+  );
+}

--- a/app/(protected)/impactindicators/[id]/page.tsx
+++ b/app/(protected)/impactindicators/[id]/page.tsx
@@ -2,7 +2,7 @@ import IndicatorUpdates from '@/components/impact-indicators/indicator-updates';
 import Breadcrumbs from '@/components/ui/breadcrumbs';
 import FeatureCard from '@/components/ui/feature-card';
 import { createClient } from '@/utils/supabase/server';
-
+import SetDateRange from '@/components/date-filtering/set-date-range';
 export default async function IndicatorUpdatesPage({
   params,
 }: {
@@ -29,12 +29,16 @@ export default async function IndicatorUpdatesPage({
   return (
     <div className='flex flex-col gap-8'>
       <Breadcrumbs />
-      <div className='flex flex-col gap-2'>
-        <h3 className='font-semibold tracking-wide text-muted-foreground'>
-          Impact Indicator {data.indicator_code}
-        </h3>
-        <h2 className='text-2xl font-semibold'>{data.indicator_title}</h2>
+      <div className='flex items-start justify-between gap-12'>
+        <div className='flex flex-col gap-2'>
+          <h3 className='font-semibold tracking-wide text-muted-foreground'>
+            Impact Indicator {data.indicator_code}
+          </h3>
+          <h2 className='text-2xl font-semibold'>{data.indicator_title}</h2>
+        </div>
+        <SetDateRange />
       </div>
+
       <IndicatorUpdates />
     </div>
   );

--- a/app/(protected)/impactindicators/[id]/page.tsx
+++ b/app/(protected)/impactindicators/[id]/page.tsx
@@ -28,7 +28,7 @@ export default async function IndicatorUpdatesPage({
 
   return (
     <div className='flex flex-col gap-8'>
-      <Breadcrumbs />
+      <Breadcrumbs type='impactindicator' />
       <div className='flex items-start justify-between gap-12'>
         <div className='flex flex-col gap-2'>
           <h3 className='font-semibold tracking-wide text-muted-foreground'>

--- a/app/(protected)/impactindicators/page.tsx
+++ b/app/(protected)/impactindicators/page.tsx
@@ -1,37 +1,18 @@
 import ImpactIndicatorList from '@/components/impact-indicators/impact-indicator-list';
 import FeatureCard from '@/components/ui/feature-card';
 import PageHeading from '@/components/ui/page-heading';
-import { createClient } from '@/utils/supabase/server';
-import { ImpactIndicator, ImpactIndicatorSummary } from '@/utils/types';
 
-export default async function ImpactIndicatorsPage() {
-  const supabase = await createClient();
-  const { data: impactIndicators, error } = await supabase
-    .from('impact_indicator_summaries')
-    .select('*')
-    .order('impact_indicator_id', { ascending: true });
-
-  if (error) {
-    <FeatureCard title='Error'>
-      <div className='flex flex-col gap-2'>
-        <h3 className='text-lg font-medium'>Error</h3>
-        <p className='text-sm text-muted-foreground'>{error.message}</p>
-      </div>
-    </FeatureCard>;
-  }
-
+export default function ImpactIndicatorsPage() {
   return (
     <div className='flex flex-col gap-6'>
       <PageHeading>Impact Indicators</PageHeading>
-      <p className=''>
+      <p>
         Summarised values are collated from updates that are{' '}
         <strong>valid</strong> and <strong>original</strong>. Duplicates and
         invalid updates are excluded.
       </p>
       <FeatureCard>
-        <ImpactIndicatorList
-          impactIndicators={impactIndicators as ImpactIndicatorSummary[]}
-        />
+        <ImpactIndicatorList />
       </FeatureCard>
     </div>
   );

--- a/components/data-tables/column-filter.tsx
+++ b/components/data-tables/column-filter.tsx
@@ -68,13 +68,13 @@ export default function ColumnFilter<TData>({
       <div className='flex items-center gap-2'>
         <input
           type='text'
-          placeholder={`Search ${label?.toLowerCase() || columnId}...`}
+          placeholder={`${label?.toLowerCase() || columnId}`}
           value={searchTerm}
           onChange={(e) => {
             setSearchTerm(e.target.value);
             table.getColumn(columnId)?.setFilterValue(e.target.value);
           }}
-          className='w-full rounded-md border px-3 py-1'
+          className='w-full rounded-md border bg-background px-3 py-1 text-sm text-foreground'
         />
       </div>
     );

--- a/components/data-tables/column-filter.tsx
+++ b/components/data-tables/column-filter.tsx
@@ -11,12 +11,14 @@ type FilterProps<TData> = {
   table: Table<TData>;
   columnId: string;
   label?: string;
+  type?: 'text' | 'list';
 };
 
 export default function ColumnFilter<TData>({
   table,
   columnId,
   label,
+  type = 'list',
 }: FilterProps<TData>) {
   const [searchTerm, setSearchTerm] = useState('');
   const column = table.getColumn(columnId);
@@ -60,6 +62,23 @@ export default function ColumnFilter<TData>({
     .split('_')
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ');
+
+  if (type === 'text') {
+    return (
+      <div className='flex items-center gap-2'>
+        <input
+          type='text'
+          placeholder={`Search ${label?.toLowerCase() || columnId}...`}
+          value={searchTerm}
+          onChange={(e) => {
+            setSearchTerm(e.target.value);
+            table.getColumn(columnId)?.setFilterValue(e.target.value);
+          }}
+          className='w-full rounded-md border px-3 py-1'
+        />
+      </div>
+    );
+  }
 
   return (
     <Popover>

--- a/components/data-tables/column-filter.tsx
+++ b/components/data-tables/column-filter.tsx
@@ -12,6 +12,7 @@ type FilterProps<TData> = {
   columnId: string;
   label?: string;
   type?: 'text' | 'list';
+  placeholder?: string;
 };
 
 export default function ColumnFilter<TData>({
@@ -19,6 +20,7 @@ export default function ColumnFilter<TData>({
   columnId,
   label,
   type = 'list',
+  placeholder,
 }: FilterProps<TData>) {
   const [searchTerm, setSearchTerm] = useState('');
   const column = table.getColumn(columnId);
@@ -65,16 +67,19 @@ export default function ColumnFilter<TData>({
 
   if (type === 'text') {
     return (
-      <div className='flex items-center gap-2'>
+      <div className='flex items-center gap-4'>
+        <label className='shrink-0 text-sm text-muted-foreground'>
+          {label || columnId}:
+        </label>
         <input
           type='text'
-          placeholder={`${label?.toLowerCase() || columnId}`}
+          placeholder={placeholder || columnId}
           value={searchTerm}
           onChange={(e) => {
             setSearchTerm(e.target.value);
             table.getColumn(columnId)?.setFilterValue(e.target.value);
           }}
-          className='w-full rounded-md border bg-background px-3 py-1 text-sm text-foreground'
+          className='h-10 w-full rounded-md border bg-background px-3 text-sm text-foreground'
         />
       </div>
     );

--- a/components/data-tables/data-table.tsx
+++ b/components/data-tables/data-table.tsx
@@ -30,6 +30,7 @@ interface DataTableProps<TData> {
     id: string;
     label: string;
     type?: 'text' | 'list';
+    placeholder?: string;
   }[];
   enableDateFilter?: boolean;
   enableExport?: boolean;
@@ -63,14 +64,14 @@ export function DataTable<TData>({
     <div className='flex flex-col gap-4'>
       <div className='flex items-center justify-between gap-4'>
         <div className='flex items-center justify-start gap-4'>
-          {filterableColumns.length > 0 && <p>Filter by:</p>}
-          {filterableColumns?.map(({ id, label, type }) => (
+          {filterableColumns?.map(({ id, label, type, placeholder }) => (
             <ColumnFilter
               key={id}
               table={table}
               columnId={id}
               label={label}
               type={type}
+              placeholder={placeholder}
             />
           ))}
           {enableDateFilter && <SetDateRange />}

--- a/components/data-tables/data-table.tsx
+++ b/components/data-tables/data-table.tsx
@@ -29,9 +29,10 @@ interface DataTableProps<TData> {
   filterableColumns?: {
     id: string;
     label: string;
+    type?: 'text' | 'list';
   }[];
   enableDateFilter?: boolean;
-  exportData?: (data: TData[]) => Record<string, any>[];
+  enableExport?: boolean;
 }
 
 export function DataTable<TData>({
@@ -39,7 +40,7 @@ export function DataTable<TData>({
   columns,
   filterableColumns = [],
   enableDateFilter = false,
-  exportData,
+  enableExport = true,
 }: DataTableProps<TData>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -63,20 +64,25 @@ export function DataTable<TData>({
       <div className='flex items-center justify-between gap-4'>
         <div className='flex items-center justify-start gap-4'>
           {filterableColumns.length > 0 && <p>Filter by:</p>}
-          {filterableColumns.map((column) => (
+          {filterableColumns?.map(({ id, label, type }) => (
             <ColumnFilter
-              key={column.id}
+              key={id}
               table={table}
-              columnId={column.id}
-              label={column.label}
+              columnId={id}
+              label={label}
+              type={type}
             />
           ))}
           {enableDateFilter && <SetDateRange />}
         </div>
 
         <div className='flex items-center gap-4'>
-          <p>{data.length} items</p>
-          {exportData && <CopyToCsvButton data={exportData(data)} />}
+          <p>{table.getFilteredRowModel().rows.length} items</p>
+          {enableExport && (
+            <CopyToCsvButton
+              data={table.getFilteredRowModel().rows.map((row) => row.original)}
+            />
+          )}
         </div>
       </div>
 

--- a/components/data-tables/data-table.tsx
+++ b/components/data-tables/data-table.tsx
@@ -22,7 +22,7 @@ import { useState } from 'react';
 import ColumnFilter from './column-filter';
 import SetDateRange from '../date-filtering/set-date-range';
 import CopyToCsvButton from './export-data';
-
+import * as d3 from 'd3';
 interface DataTableProps<TData> {
   data: TData[];
   columns: ColumnDef<TData>[];
@@ -78,7 +78,7 @@ export function DataTable<TData>({
         </div>
 
         <div className='flex items-center gap-4'>
-          <p>{table.getFilteredRowModel().rows.length} items</p>
+          <p>{d3.format(',')(table.getFilteredRowModel().rows.length)} items</p>
           {enableExport && (
             <CopyToCsvButton
               data={table.getFilteredRowModel().rows.map((row) => row.original)}

--- a/components/date-filtering/preset-date-ranges.ts
+++ b/components/date-filtering/preset-date-ranges.ts
@@ -13,11 +13,11 @@ import {
 
 export const presetButtons = [
   { key: 'lastWeek', label: 'Last Week' },
-  { key: 'last30days', label: 'Last 30 Days' },
   { key: 'lastMonth', label: 'Last Month' },
   { key: 'last3months', label: 'Last 3 Months' },
   { key: 'yearToDate', label: 'Year to Date' },
   { key: 'lastYear', label: 'Last Year' },
+  { key: 'allTime', label: 'All Time' },
 ];
 
 const presetDateRanges: Record<string, () => { dateRange: DateRange }> = {
@@ -27,15 +27,6 @@ const presetDateRanges: Record<string, () => { dateRange: DateRange }> = {
       dateRange: {
         from: startOfWeek(subDays(now, 7), { weekStartsOn: 1 }),
         to: endOfWeek(subDays(now, 7), { weekStartsOn: 1 }),
-      },
-    };
-  },
-  last30days: () => {
-    const now = new Date();
-    return {
-      dateRange: {
-        from: subDays(now, 30),
-        to: now,
       },
     };
   },
@@ -73,6 +64,15 @@ const presetDateRanges: Record<string, () => { dateRange: DateRange }> = {
       dateRange: {
         from: startOfYear(subYears(now, 1)),
         to: endOfYear(subYears(now, 1)),
+      },
+    };
+  },
+  allTime: () => {
+    const now = new Date();
+    return {
+      dateRange: {
+        from: new Date(2009, 5, 12),
+        to: now,
       },
     };
   },

--- a/components/date-filtering/use-url-date-state.ts
+++ b/components/date-filtering/use-url-date-state.ts
@@ -1,4 +1,4 @@
-import { startOfMonth, format } from 'date-fns';
+import { startOfYear, format } from 'date-fns';
 import { useSearchParams } from 'next/navigation';
 
 export interface DateState {
@@ -6,7 +6,7 @@ export interface DateState {
   to: string;
 }
 
-export const defaultFrom = startOfMonth(new Date());
+export const defaultFrom = startOfYear(new Date());
 export const defaultTo = new Date();
 
 export default function useUrlDateState(): DateState {

--- a/components/footer/footer.tsx
+++ b/components/footer/footer.tsx
@@ -4,7 +4,7 @@ export default function Footer() {
       <div className='max-w-app mx-auto flex items-baseline justify-between'>
         <p className='mb-[2em] text-sm'>Powered by Blue Marine Foundation</p>
         <p className='text-xs'>
-          &copy; Blue Marine Foundation, 2024 and beyond...
+          &copy; Blue Marine Foundation, 2025 and beyond...
         </p>
       </div>
     </footer>

--- a/components/header/primary-nav.tsx
+++ b/components/header/primary-nav.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { usePathname } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 
 interface NavItem {
@@ -9,6 +9,8 @@ interface NavItem {
 
 export default function PrimaryNavigation() {
   const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const hasSearchParams = searchParams && searchParams.toString().length > 0;
 
   const items = [
     {
@@ -38,7 +40,7 @@ export default function PrimaryNavigation() {
             className={` ${pathname === item.href && 'active'} group inline-block leading-4 transition-all`}
           >
             <Link
-              href={item.href}
+              href={`${item.href}${hasSearchParams ? `?${searchParams.toString()}` : ''}`}
               className='inline-block rounded-md border border-transparent px-4 py-2 text-foreground/80 transition-all ease-in-out hover:border-foreground/20 group-[.active]:border-slate-800 group-[.active]:bg-sky-800/50 group-[.active]:text-foreground'
             >
               {item.name}

--- a/components/impact-indicators/columns.tsx
+++ b/components/impact-indicators/columns.tsx
@@ -12,7 +12,7 @@ export const columns: ColumnDef<ImpactIndicatorSummary>[] = [
       const code = row.getValue('indicator_code') as string;
       return (
         <div
-          className={`text-right ${
+          className={`max-w-20 text-right ${
             code.length < 2 && 'font-medium'
           } ${code.length < 4 && 'text-muted-foreground'}`}
         >

--- a/components/impact-indicators/columns.tsx
+++ b/components/impact-indicators/columns.tsx
@@ -3,6 +3,8 @@
 import { ImpactIndicatorSummary } from '@/utils/types';
 import { ColumnDef } from '@tanstack/react-table';
 import * as d3 from 'd3';
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 
 export const columns: ColumnDef<ImpactIndicatorSummary>[] = [
   {
@@ -32,13 +34,23 @@ export const columns: ColumnDef<ImpactIndicatorSummary>[] = [
     },
     cell: ({ row }) => {
       const code = row.original.indicator_code;
+      const searchParams = useSearchParams();
+      const hasSearchParams =
+        searchParams && searchParams.toString().length > 0;
       return (
         <div
           className={`max-w-prose ${
             code.length < 2 && 'font-medium'
           } ${code.length < 4 && 'text-muted-foreground'}`}
         >
-          {row.getValue('indicator_title')}
+          <Link
+            href={`/impactindicators/${row.original.impact_indicator_id}${
+              hasSearchParams ? `?${searchParams.toString()}` : ''
+            }`}
+            className='hover:underline'
+          >
+            {row.getValue('indicator_title')}
+          </Link>
         </div>
       );
     },

--- a/components/impact-indicators/columns.tsx
+++ b/components/impact-indicators/columns.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { ImpactIndicatorSummary } from '@/utils/types';
+import { ColumnDef } from '@tanstack/react-table';
+import * as d3 from 'd3';
+
+export const columns: ColumnDef<ImpactIndicatorSummary>[] = [
+  {
+    accessorKey: 'indicator_code',
+    header: 'Indicator Code',
+    cell: ({ row }) => {
+      const code = row.getValue('indicator_code') as string;
+      return (
+        <div
+          className={`text-right ${
+            code.length < 2 && 'font-medium'
+          } ${code.length < 4 && 'text-muted-foreground'}`}
+        >
+          {code}
+        </div>
+      );
+    },
+  },
+  {
+    accessorKey: 'indicator_title',
+    header: 'Indicator Title',
+    filterFn: (row, columnId, filterValue) => {
+      const title = row.getValue(columnId) as string;
+      return title
+        .toLowerCase()
+        .includes((filterValue as string).toLowerCase());
+    },
+    cell: ({ row }) => {
+      const code = row.original.indicator_code;
+      return (
+        <div
+          className={`max-w-prose ${
+            code.length < 2 && 'font-medium'
+          } ${code.length < 4 && 'text-muted-foreground'}`}
+        >
+          {row.getValue('indicator_title')}
+        </div>
+      );
+    },
+  },
+  {
+    accessorKey: 'valid_updates',
+    header: 'Valid Updates',
+    cell: ({ row }) => {
+      const code = row.original.indicator_code;
+      if (code.length <= 3) return null;
+      return <div className='text-right'>{row.getValue('valid_updates')}</div>;
+    },
+  },
+  {
+    accessorKey: 'total_value',
+    header: 'Total Value',
+    cell: ({ row }) => {
+      const code = row.original.indicator_code;
+      if (code.length <= 3) return null;
+      return (
+        <div className='text-right'>
+          {d3.format(',.0f')(row.getValue('total_value'))}
+        </div>
+      );
+    },
+  },
+  {
+    accessorKey: 'indicator_unit',
+    header: 'Unit',
+    cell: ({ row }) => {
+      const code = row.original.indicator_code;
+      if (code.length <= 3) return null;
+      return (
+        <div className='text-muted-foreground'>
+          {row.getValue('indicator_unit')}
+        </div>
+      );
+    },
+  },
+];

--- a/components/impact-indicators/impact-indicator-list.tsx
+++ b/components/impact-indicators/impact-indicator-list.tsx
@@ -33,8 +33,10 @@ export default function ImpactIndicatorList() {
           id: 'indicator_title',
           label: 'Search indicators',
           type: 'text',
+          placeholder: 'e.g. "species"',
         },
       ]}
+      enableDateFilter
       enableExport
     />
   );

--- a/components/impact-indicators/impact-indicator-list.tsx
+++ b/components/impact-indicators/impact-indicator-list.tsx
@@ -5,11 +5,14 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchImpactIndicators } from './server-actions';
 import { DataTable } from '../data-tables/data-table';
 import { columns } from './columns';
+import useUrlDateState from '@/components/date-filtering/use-url-date-state';
 
 export default function ImpactIndicatorList() {
+  const { from, to } = useUrlDateState();
+
   const { data: impactIndicators, error } = useQuery({
-    queryKey: ['impact-indicators'],
-    queryFn: fetchImpactIndicators,
+    queryKey: ['impact-indicators', from, to],
+    queryFn: () => fetchImpactIndicators(from, to),
   });
 
   if (error) {

--- a/components/impact-indicators/impact-indicator-list.tsx
+++ b/components/impact-indicators/impact-indicator-list.tsx
@@ -1,96 +1,41 @@
 'use client';
 
 import { ImpactIndicatorSummary } from '@/utils/types';
-import { Fragment, useState } from 'react';
-import * as d3 from 'd3';
+import { useQuery } from '@tanstack/react-query';
+import { fetchImpactIndicators } from './server-actions';
+import { DataTable } from '../data-tables/data-table';
+import { columns } from './columns';
 
-export default function ImpactIndicatorList({
-  impactIndicators,
-}: {
-  impactIndicators: ImpactIndicatorSummary[];
-}) {
-  const [searchQuery, setSearchQuery] = useState('');
+export default function ImpactIndicatorList() {
+  const { data: impactIndicators, error } = useQuery({
+    queryKey: ['impact-indicators'],
+    queryFn: fetchImpactIndicators,
+  });
 
-  const filteredIndicators =
-    impactIndicators?.filter((impactIndicator) =>
-      impactIndicator.indicator_title
-        ?.toLowerCase()
-        .includes(searchQuery.toLowerCase()),
-    ) ?? [];
+  if (error) {
+    return <p>{(error as Error).message}</p>;
+  }
+
+  if (!impactIndicators) {
+    return (
+      <p className='flex h-[500px] w-full items-center justify-center'>
+        Loading impact indicators...
+      </p>
+    );
+  }
 
   return (
-    <div className='flex flex-col gap-6'>
-      <div className='flex items-center gap-4'>
-        <label htmlFor='search' className='sr-only text-sm text-foreground'>
-          Filter impact indicators:
-        </label>
-        <input
-          id='search'
-          name='search'
-          type='text'
-          placeholder='Search...'
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          className='w-80 rounded-md border bg-background px-2 py-1'
-        />
-      </div>
-
-      <div className='flex flex-col gap-2'>
-        <div className='grid grid-cols-[1fr_5fr_1fr_1fr_2fr] justify-start gap-6 text-sm'>
-          <div className='text-right font-semibold'>
-            <h3>Indicator Code</h3>
-          </div>
-          <div className='max-w-prose font-semibold'>
-            <h3>Indicator Title</h3>
-          </div>
-          <div className='text-right font-semibold'>
-            <h3>Valid Updates</h3>
-          </div>
-          <div className='text-right font-semibold'>
-            <h3>Total Value</h3>
-          </div>
-          <div className='font-semibold'>
-            <h3>Unit</h3>
-          </div>
-
-          {filteredIndicators.map((impactIndicator) => (
-            <Fragment key={impactIndicator.impact_indicator_id}>
-              <div
-                className={`text-right ${impactIndicator.indicator_code.length < 2 && 'text-base font-medium'} ${
-                  impactIndicator.indicator_code.length < 4 &&
-                  'text-muted-foreground'
-                }`}
-              >
-                {impactIndicator.indicator_code}
-              </div>
-              <div
-                className={`max-w-prose ${impactIndicator.indicator_code.length < 2 && 'text-base font-medium'} ${
-                  impactIndicator.indicator_code.length < 4 &&
-                  'text-muted-foreground'
-                }`}
-              >
-                {impactIndicator.indicator_title}
-              </div>
-              {impactIndicator.indicator_code.length > 3 ? (
-                <>
-                  <div className='text-right'>
-                    {impactIndicator.valid_updates}
-                  </div>
-
-                  <div className='text-right'>
-                    {d3.format(',.0f')(impactIndicator.total_value)}
-                  </div>
-                  <div className='text-muted-foreground'>
-                    {impactIndicator.indicator_unit}
-                  </div>
-                </>
-              ) : (
-                <div className='col-span-3' />
-              )}
-            </Fragment>
-          ))}
-        </div>
-      </div>
-    </div>
+    <DataTable<ImpactIndicatorSummary>
+      data={impactIndicators}
+      columns={columns}
+      filterableColumns={[
+        {
+          id: 'indicator_title',
+          label: 'Search indicators',
+          type: 'text',
+        },
+      ]}
+      enableExport
+    />
   );
 }

--- a/components/impact-indicators/impact-indicator-list.tsx
+++ b/components/impact-indicators/impact-indicator-list.tsx
@@ -2,7 +2,7 @@
 
 import { ImpactIndicatorSummary } from '@/utils/types';
 import { useQuery } from '@tanstack/react-query';
-import { fetchImpactIndicators } from './server-actions';
+import { fetchImpactIndicatorSummaries } from './server-actions';
 import { DataTable } from '../data-tables/data-table';
 import { columns } from './columns';
 import useUrlDateState from '@/components/date-filtering/use-url-date-state';
@@ -12,7 +12,7 @@ export default function ImpactIndicatorList() {
 
   const { data: impactIndicators, error } = useQuery({
     queryKey: ['impact-indicators', from, to],
-    queryFn: () => fetchImpactIndicators(from, to),
+    queryFn: () => fetchImpactIndicatorSummaries(from, to),
   });
 
   if (error) {

--- a/components/impact-indicators/indicator-projects-columns.tsx
+++ b/components/impact-indicators/indicator-projects-columns.tsx
@@ -1,0 +1,43 @@
+import { ColumnDef } from '@tanstack/react-table';
+import Link from 'next/link';
+import * as d3 from 'd3';
+
+interface ProjectRow {
+  name: string;
+  slug: string;
+  count: number;
+  valueSum: number;
+  unit: string;
+}
+
+export const columns: ColumnDef<ProjectRow>[] = [
+  {
+    header: 'Project',
+    accessorKey: 'name',
+    cell: ({ row }: { row: { original: ProjectRow } }) => {
+      return (
+        <Link href={`/projects/${row.original.slug}`} className=''>
+          {row.original.name}
+        </Link>
+      );
+    },
+  },
+  {
+    header: 'Count',
+    accessorKey: 'count',
+  },
+  {
+    header: 'Total Value',
+    accessorKey: 'valueSum',
+    cell: ({ row }) => {
+      return d3.format(',')(row.getValue('valueSum'));
+    },
+  },
+  {
+    header: 'Unit',
+    accessorKey: 'unit',
+    cell: ({ row }) => {
+      return row.getValue('unit');
+    },
+  },
+];

--- a/components/impact-indicators/indicator-updates-columns.tsx
+++ b/components/impact-indicators/indicator-updates-columns.tsx
@@ -1,0 +1,180 @@
+import { Update } from '@/utils/types';
+import { ColumnDef } from '@tanstack/react-table';
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '@/components/ui/hover-card';
+import Link from 'next/link';
+import * as d3 from 'd3';
+import { ArrowUpRight } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { format } from 'date-fns';
+import UpdateForm from '@/components/updates/update-form';
+
+export const columns: ColumnDef<Update>[] = [
+  {
+    header: 'Date',
+    accessorKey: 'date',
+    accessorFn: (row) => row.date,
+    filterFn: (row, columnId, filterValue) => {
+      if (!filterValue || filterValue.length === 0) return true;
+      return filterValue.includes(row.getValue(columnId));
+    },
+    cell: ({ row }) => {
+      return (
+        <p className='whitespace-nowrap text-muted-foreground'>
+          {format(row.original.date, 'd MMM yyyy')}
+        </p>
+      );
+    },
+  },
+  {
+    header: 'Project',
+    accessorKey: 'project',
+    accessorFn: (row) => row.projects?.name,
+    filterFn: (row, columnId, filterValue) => {
+      if (!filterValue || filterValue.length === 0) return true;
+      return filterValue.includes(row.getValue(columnId));
+    },
+    cell: ({ row }) => {
+      return (
+        <Link
+          href={`/projects/${row.original.projects?.slug}`}
+          className='block max-w-[150px] truncate'
+        >
+          {row.original.projects?.name}
+        </Link>
+      );
+    },
+  },
+  {
+    header: 'Output Indicator',
+    accessorKey: 'output_measurable',
+    accessorFn: (row) => row.output_measurables?.code,
+    filterFn: (row, columnId, filterValue) => {
+      if (!filterValue || filterValue.length === 0) return true;
+      return filterValue.includes(row.getValue(columnId));
+    },
+    cell: ({ row }) => {
+      return (
+        <HoverCard>
+          <HoverCardTrigger>
+            {row.original.output_measurables?.code}
+          </HoverCardTrigger>
+          <HoverCardContent>
+            <p>{row.original.output_measurables?.description}</p>
+          </HoverCardContent>
+        </HoverCard>
+      );
+    },
+  },
+  {
+    header: 'Type',
+    accessorKey: 'type',
+    accessorFn: (row) => row.type,
+    filterFn: (row, columnId, filterValue) => {
+      if (!filterValue || filterValue.length === 0) return true;
+      return filterValue.includes(row.getValue(columnId));
+    },
+  },
+  {
+    header: 'Description',
+    accessorKey: 'description',
+    accessorFn: (row) => row.description,
+    filterFn: (row, columnId, filterValue) => {
+      if (!filterValue || filterValue.length === 0) return true;
+      return filterValue.includes(row.getValue(columnId));
+    },
+    cell: ({ row }) => {
+      return <p className='max-w-prose'>{row.getValue('description')}</p>;
+    },
+  },
+  {
+    header: 'Impact',
+    accessorKey: 'value',
+    accessorFn: (row) => row.value,
+    filterFn: (row, columnId, filterValue) => {
+      if (!filterValue || filterValue.length === 0) return true;
+      return filterValue.includes(row.getValue(columnId));
+    },
+    cell: ({ row }) => {
+      return (
+        <div className='flex flex-col gap-1'>
+          <p>
+            {row.original.value && (
+              <span>
+                {d3.format(
+                  Number.isInteger(row.original.value) ||
+                    row.original.value >= 100
+                    ? ',.0f'
+                    : ',.2f',
+                )(row.original.value)}
+              </span>
+            )}{' '}
+            {row.original.value &&
+              row.original.impact_indicators?.indicator_unit && (
+                <span className='text-muted-foreground'>
+                  {row.original.impact_indicators?.indicator_unit}
+                </span>
+              )}
+          </p>
+          {row.original.link && (
+            <p className='text-sky-500'>
+              <Link href={row.original.link} target='_blank'>
+                Linked evidence <ArrowUpRight className='inline h-3 w-3' />
+              </Link>
+            </p>
+          )}
+        </div>
+      );
+    },
+  },
+  {
+    header: 'Posted by',
+    accessorKey: 'posted_by',
+    accessorFn: (row) => row.users?.first_name + ' ' + row.users?.last_name,
+    filterFn: (row, columnId, filterValue) => {
+      if (!filterValue || filterValue.length === 0) return true;
+      return filterValue.includes(row.getValue(columnId));
+    },
+    cell: ({ row }) => {
+      return (
+        <p className='max-w-prose whitespace-nowrap'>
+          {row.original.users?.first_name} {row.original.users?.last_name}
+        </p>
+      );
+    },
+  },
+  {
+    id: 'edit',
+    cell: ({ row }) => {
+      return (
+        <Dialog>
+          <DialogTrigger asChild>
+            <button className='rounded-md border px-2 py-1 text-muted-foreground'>
+              Edit
+            </button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Edit update</DialogTitle>
+            </DialogHeader>
+            <UpdateForm
+              outputMeasurable={row.original.output_measurables!}
+              impactIndicator={row.original.impact_indicators!}
+              projectId={row.original.projects?.id!}
+              update={row.original}
+            />
+          </DialogContent>
+        </Dialog>
+      );
+    },
+  },
+];

--- a/components/impact-indicators/indicator-updates.tsx
+++ b/components/impact-indicators/indicator-updates.tsx
@@ -62,12 +62,12 @@ export default function IndicatorUpdates() {
             <h3 className='text-sm font-medium text-muted-foreground'>
               Total value
             </h3>
+            <p className='text-balance text-sm'>{project_summaries[0]?.unit}</p>
             <h2 className='text-right text-3xl font-bold'>
-              {d3.format(',.2f')(
+              {d3.format(',')(
                 d3.sum(project_summaries, (d) => d.valueSum || 0),
               )}
             </h2>
-            <p className='text-right text-sm'>{project_summaries[0]?.unit}</p>
           </div>
         </div>
         <div className='grow'>

--- a/components/impact-indicators/indicator-updates.tsx
+++ b/components/impact-indicators/indicator-updates.tsx
@@ -7,6 +7,10 @@ import { fetchImpactIndicatorUpdates } from '@/components/impact-indicators/serv
 import { Update } from '@/utils/types';
 import { useParams } from 'next/navigation';
 import useUrlDateState from '@/components/date-filtering/use-url-date-state';
+import FeatureCard from '../ui/feature-card';
+import { rollup } from 'd3-array';
+import * as d3 from 'd3';
+import { columns as projectSummariesColumns } from '@/components/impact-indicators/indicator-projects-columns';
 
 export default function IndicatorUpdates() {
   const { id } = useParams();
@@ -14,7 +18,8 @@ export default function IndicatorUpdates() {
 
   const { data, error, isLoading } = useQuery({
     queryKey: ['impact-indicator', id, dateRange],
-    queryFn: () => fetchImpactIndicatorUpdates(id as string),
+    queryFn: () =>
+      fetchImpactIndicatorUpdates(id as string, dateRange.from, dateRange.to),
   });
 
   if (isLoading) {
@@ -27,9 +32,22 @@ export default function IndicatorUpdates() {
     );
   }
 
-  const projects = Array.from(
-    new Set(data?.map((update: Update) => update.projects?.name)),
-  ).sort() as Array<string>;
+  const project_summaries = Array.from(
+    rollup(
+      data || [],
+      (v) => ({
+        slug: v[0].projects?.slug,
+        count: v.length,
+        valueSum: d3.sum(v, (d) => d.value || 0),
+        unit: v[0].impact_indicators?.indicator_unit,
+      }),
+      (d) => d.projects.name,
+    ),
+    ([name, values]) => ({
+      name,
+      ...values,
+    }),
+  ).sort((a, b) => (a.name || '').localeCompare(b.name || ''));
 
   const filterableColumns = [
     { id: 'project', label: 'Project' },
@@ -38,17 +56,40 @@ export default function IndicatorUpdates() {
 
   return (
     <div className='flex flex-col gap-8'>
-      <p>
-        {projects.length} projects:{' '}
-        {projects.map((project: string) => project).join(', ')}
-      </p>
-      <DataTable
-        data={data as Update[]}
-        columns={columns}
-        filterableColumns={filterableColumns}
-        enableDateFilter
-        enableExport
-      />
+      <div className='flex items-start justify-between gap-4'>
+        <div className='sticky top-8 w-1/4 rounded-md bg-card p-4'>
+          <div className='flex flex-col gap-4'>
+            <h3 className='text-sm font-medium text-muted-foreground'>
+              Total value
+            </h3>
+            <h2 className='text-right text-3xl font-bold'>
+              {d3.format(',.2f')(
+                d3.sum(project_summaries, (d) => d.valueSum || 0),
+              )}
+            </h2>
+            <p className='text-right text-sm'>{project_summaries[0]?.unit}</p>
+          </div>
+        </div>
+        <div className='grow'>
+          <FeatureCard>
+            <DataTable
+              data={project_summaries}
+              filterableColumns={[{ id: 'name', label: 'Project' }]}
+              columns={projectSummariesColumns}
+              enableExport
+            />
+          </FeatureCard>
+        </div>
+      </div>
+      <FeatureCard>
+        <DataTable
+          data={data as Update[]}
+          columns={columns}
+          filterableColumns={filterableColumns}
+          enableDateFilter={false}
+          enableExport
+        />
+      </FeatureCard>
     </div>
   );
 }

--- a/components/impact-indicators/indicator-updates.tsx
+++ b/components/impact-indicators/indicator-updates.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { DataTable } from '@/components/data-tables/data-table';
+import { columns } from '@/components/impact-indicators/indicator-updates-columns';
+import { useQuery } from '@tanstack/react-query';
+import { fetchImpactIndicatorUpdates } from '@/components/impact-indicators/server-actions';
+import { Update } from '@/utils/types';
+import { useParams } from 'next/navigation';
+import useUrlDateState from '@/components/date-filtering/use-url-date-state';
+
+export default function IndicatorUpdates() {
+  const { id } = useParams();
+  const dateRange = useUrlDateState();
+
+  const { data, error, isLoading } = useQuery({
+    queryKey: ['impact-indicator', id, dateRange],
+    queryFn: () => fetchImpactIndicatorUpdates(id as string),
+  });
+
+  if (isLoading) {
+    return <div>Loading impact indicator...</div>;
+  }
+
+  if (error) {
+    return (
+      <div>Error loading impact indicator: {(error as Error).message}</div>
+    );
+  }
+
+  const projects = Array.from(
+    new Set(data?.map((update: Update) => update.projects?.name)),
+  ).sort() as Array<string>;
+
+  const filterableColumns = [
+    { id: 'project', label: 'Project' },
+    { id: 'type', label: 'Update Type' },
+  ];
+
+  return (
+    <div className='flex flex-col gap-8'>
+      <p>
+        {projects.length} projects:{' '}
+        {projects.map((project: string) => project).join(', ')}
+      </p>
+      <DataTable
+        data={data as Update[]}
+        columns={columns}
+        filterableColumns={filterableColumns}
+        enableDateFilter
+        enableExport
+      />
+    </div>
+  );
+}

--- a/components/impact-indicators/server-actions.ts
+++ b/components/impact-indicators/server-actions.ts
@@ -33,12 +33,20 @@ export async function fetchImpactIndicatorSummaries(
   return data;
 }
 
-export async function fetchImpactIndicatorUpdates(id: string) {
+export async function fetchImpactIndicatorUpdates(
+  id: string,
+  fromDate: string,
+  toDate: string,
+) {
   const supabase = await createClient();
   const { data, error } = await supabase
     .from('updates')
-    .select('*, projects(slug, name), output_measurables(*), users(*)')
+    .select(
+      '*, projects(slug, name), output_measurables(*), impact_indicators(id, indicator_unit), users(*)',
+    )
     .match({ impact_indicator_id: id, original: true, valid: true })
+    .gte('date', fromDate)
+    .lte('date', toDate)
     .order('date', { ascending: false });
 
   if (error) {

--- a/components/impact-indicators/server-actions.ts
+++ b/components/impact-indicators/server-actions.ts
@@ -2,12 +2,12 @@
 
 import { createClient } from '@/utils/supabase/server';
 
-export async function fetchImpactIndicators() {
+export async function fetchImpactIndicators(fromDate: string, toDate: string) {
   const supabase = await createClient();
-  const { data, error } = await supabase
-    .from('impact_indicator_summaries')
-    .select('*')
-    .order('impact_indicator_id', { ascending: true });
+  const { data, error } = await supabase.rpc('get_impact_indicator_summaries', {
+    from_date: fromDate,
+    to_date: toDate,
+  });
 
   if (error) {
     throw new Error(error.message);

--- a/components/impact-indicators/server-actions.ts
+++ b/components/impact-indicators/server-actions.ts
@@ -1,15 +1,17 @@
 'use server';
 
 import { createClient } from '@/utils/supabase/server';
-import type { ImpactIndicator } from '@/utils/types';
 
-export const fetchImpactIndicators = async () => {
+export async function fetchImpactIndicators() {
   const supabase = await createClient();
   const { data, error } = await supabase
-    .from('impact_indicators')
+    .from('impact_indicator_summaries')
     .select('*')
-    .order('indicator_code');
+    .order('impact_indicator_id', { ascending: true });
 
-  if (error) throw error;
-  return data as ImpactIndicator[];
-};
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data;
+}

--- a/components/impact-indicators/server-actions.ts
+++ b/components/impact-indicators/server-actions.ts
@@ -2,7 +2,24 @@
 
 import { createClient } from '@/utils/supabase/server';
 
-export async function fetchImpactIndicators(fromDate: string, toDate: string) {
+export async function fetchImpactIndicators() {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('impact_indicators')
+    .select('*')
+    .order('id', { ascending: true });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data;
+}
+
+export async function fetchImpactIndicatorSummaries(
+  fromDate: string,
+  toDate: string,
+) {
   const supabase = await createClient();
   const { data, error } = await supabase.rpc('get_impact_indicator_summaries', {
     from_date: fromDate,

--- a/components/impact-indicators/server-actions.ts
+++ b/components/impact-indicators/server-actions.ts
@@ -32,3 +32,18 @@ export async function fetchImpactIndicatorSummaries(
 
   return data;
 }
+
+export async function fetchImpactIndicatorUpdates(id: string) {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('updates')
+    .select('*, projects(slug, name), output_measurables(*), users(*)')
+    .match({ impact_indicator_id: id, original: true, valid: true })
+    .order('date', { ascending: false });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data;
+}

--- a/components/ui/breadcrumbs.tsx
+++ b/components/ui/breadcrumbs.tsx
@@ -1,23 +1,27 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 import { ChevronRight } from 'lucide-react';
 
 interface BreadcrumbsProps {
   projectName?: string;
+  type?: 'impactindicator' | 'project';
 }
 
-export default function Breadcrumbs({ projectName }: BreadcrumbsProps) {
+export default function Breadcrumbs({ projectName, type }: BreadcrumbsProps) {
   const pathname = usePathname();
   const pathSegments = pathname.split('/').filter((segment) => segment);
-
+  const searchParams = useSearchParams();
+  const hasSearchParams = searchParams && searchParams.toString().length > 0;
   const breadcrumbs = [
     { name: 'Home', path: '/' },
     ...pathSegments.map((segment, index) => {
       let name = segment;
       if (segment === 'projects') name = 'Projects';
       else if (index === 1 && projectName) name = projectName;
+      else if (type === 'impactindicator' && index === 0)
+        name = 'Impact Indicators';
       else {
         // Handle hyphenated segments by splitting, capitalizing each word, and joining
         name = segment
@@ -28,7 +32,9 @@ export default function Breadcrumbs({ projectName }: BreadcrumbsProps) {
 
       return {
         name,
-        path: `/${pathSegments.slice(0, index + 1).join('/')}`,
+        path: `/${pathSegments.slice(0, index + 1).join('/')}${
+          hasSearchParams ? `?${searchParams.toString()}` : ''
+        }`,
       };
     }),
   ];

--- a/components/updates/project-updates-data-table.tsx
+++ b/components/updates/project-updates-data-table.tsx
@@ -43,7 +43,7 @@ export default function ProjectUpdatesDataTable({
       columns={columns}
       filterableColumns={filterableColumns}
       enableDateFilter
-      exportData={flattenUpdates}
+      enableExport
     />
   );
 }

--- a/components/updates/updates-data-table.tsx
+++ b/components/updates/updates-data-table.tsx
@@ -6,6 +6,7 @@ import { fetchUpdates } from './server-actions';
 import useUrlDateState from '../date-filtering/use-url-date-state';
 import { DataTable } from '../data-tables/data-table';
 import { Update } from '@/utils/types';
+import FeatureCard from '../ui/feature-card';
 
 const filterableColumns = [
   { id: 'project', label: 'Project' },
@@ -34,12 +35,14 @@ export default function UpdatesDataTable() {
   }
 
   return (
-    <DataTable<Update>
-      data={data}
-      columns={columns}
-      filterableColumns={filterableColumns}
-      enableDateFilter
-      enableExport
-    />
+    <FeatureCard>
+      <DataTable<Update>
+        data={data}
+        columns={columns}
+        filterableColumns={filterableColumns}
+        enableDateFilter
+        enableExport
+      />
+    </FeatureCard>
   );
 }

--- a/components/updates/updates-data-table.tsx
+++ b/components/updates/updates-data-table.tsx
@@ -5,7 +5,6 @@ import { columns } from './updates-table-columns';
 import { fetchUpdates } from './server-actions';
 import useUrlDateState from '../date-filtering/use-url-date-state';
 import { DataTable } from '../data-tables/data-table';
-import { flattenUpdates } from './flatten-updates';
 import { Update } from '@/utils/types';
 
 const filterableColumns = [

--- a/components/updates/updates-data-table.tsx
+++ b/components/updates/updates-data-table.tsx
@@ -40,7 +40,7 @@ export default function UpdatesDataTable() {
       columns={columns}
       filterableColumns={filterableColumns}
       enableDateFilter
-      exportData={flattenUpdates}
+      enableExport
     />
   );
 }


### PR DESCRIPTION
Adds impact indicator pages to new Maerl, improving on their old implementation by using TanStack Query for state management, and simplifying the calculation of the impact totals via Postgres views (managed via Supabase studio). 

- Closes #116 
- Closes #96
- Closes #121 
- Closes #98 