### PR TITLE
Feature: Logframe Output Activities List

### DIFF
--- a/components/logframe/extractOutputActivityCodeNumber.ts
+++ b/components/logframe/extractOutputActivityCodeNumber.ts
@@ -1,0 +1,8 @@
+/**
+ * Extracts the numeric part after the decimal point from an Output code
+ * @param code Format example: "A01" or "A02"
+ * @returns The numeric value after the A
+ */
+export function extractOutputActivityCodeNumber(code: string): number {
+  return parseInt(code.split('A')[1]);
+}

--- a/components/logframe/logframe-text.ts
+++ b/components/logframe/logframe-text.ts
@@ -14,4 +14,9 @@ export const logframeText = {
     description:
       "Outputs are specific, direct deliverables that result from the project's activities. The Outputs should be fully within the control of the project, providing the assumptions hold. Taken together, the outputs should provide the conditions necessary to achieve the Outcome. Wherever possible it should be clear who will benefit from the output, and how they will benefit.",
   },
+  activity: {
+    title: 'Activity',
+    description:
+      'Activities are specific actions or tasks that contribute to achieving the output. They should be clear, concrete, and measurable.',
+  },
 };

--- a/components/logframe/output-activities-list.tsx
+++ b/components/logframe/output-activities-list.tsx
@@ -37,7 +37,6 @@ export default function OutputActivitiesList({
           <div className='rounded-md border bg-card p-4'>
             <div className='flex items-center gap-2'>
               <p className='font-medium text-muted-foreground'>Activities</p>
-
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger>

--- a/components/logframe/output-activities-list.tsx
+++ b/components/logframe/output-activities-list.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useState } from 'react';
+import { Output, OutputActivity } from '@/utils/types';
+import ActionButton from '@/components/ui/action-button';
+import { Badge, BadgeProps } from '../ui/badge';
+import { Info } from 'lucide-react';
+import { extractOutputActivityCodeNumber } from './extractOutputActivityCodeNumber';
+import { logframeText } from './logframe-text';
+import OutputActivityForm from './output-activity-form';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '../ui/tooltip';
+
+interface OutputActivitiesListProps {
+  activities: OutputActivity[];
+  output: Output;
+  projectId: number;
+}
+
+export default function OutputActivitiesList({
+  activities,
+  output,
+  projectId,
+}: OutputActivitiesListProps) {
+  const [isActivityDialogOpen, setIsActivityDialogOpen] = useState(false);
+  const [selectedActivity, setSelectedActivity] =
+    useState<OutputActivity | null>(null);
+
+  return (
+    <div className='flex flex-col gap-4'>
+      {activities && activities.length > 0 ? (
+        <div>
+          <div className='rounded-md border bg-card p-4'>
+            <div className='flex items-center gap-2'>
+              <p className='font-medium text-muted-foreground'>Activities</p>
+
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <Info className='h-4 w-4 text-white/60 hover:text-white' />
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p className='max-w-xs text-sm'>
+                      {logframeText.activity.description}
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
+            <ol className='mt-2 list-none'>
+              {activities.map((activity) => (
+                <li key={activity.id} className='my-4'>
+                  <div className='flex items-start gap-4'>
+                    <ActionButton
+                      action='edit'
+                      variant='icon'
+                      onClick={() => {
+                        setSelectedActivity(activity);
+                        setIsActivityDialogOpen(true);
+                      }}
+                    />
+
+                    <span className='text-sm'>
+                      {`${extractOutputActivityCodeNumber(
+                        activity.activity_code,
+                      )}.`}
+                    </span>
+                    <span className='max-w-prose text-sm'>
+                      {activity.activity_description}
+                    </span>
+                    {activity.activity_status && (
+                      <Badge
+                        variant={
+                          activity.activity_status
+                            .toLowerCase()
+                            .replace(' ', '_') as BadgeProps['variant']
+                        }
+                      >
+                        {activity.activity_status}
+                      </Badge>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </div>
+          <ActionButton
+            action='add'
+            label='Add activity'
+            onClick={() => setIsActivityDialogOpen(true)}
+            className='mt-6'
+          />
+        </div>
+      ) : (
+        <div className='mt-2 flex items-center justify-center rounded-md border border-dashed p-12'>
+          <ActionButton
+            action='add'
+            label='Add activity'
+            onClick={() => setIsActivityDialogOpen(true)}
+          />
+        </div>
+      )}
+
+      <OutputActivityForm
+        isOpen={isActivityDialogOpen}
+        onClose={() => {
+          setIsActivityDialogOpen(false);
+          setSelectedActivity(null);
+        }}
+        activity={selectedActivity}
+        activities={activities}
+        projectId={projectId}
+        output={output}
+      />
+    </div>
+  );
+}

--- a/components/logframe/output-activity-form.tsx
+++ b/components/logframe/output-activity-form.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../ui/dialog';
+import { Output, OutputActivity } from '@/utils/types';
+import CalloutCard from './callout-card';
+import { upsertOutputActivity } from './server-actions';
+import { logframeText } from './logframe-text';
+
+interface OutputActivityFormProps {
+  isOpen: boolean;
+  onClose: () => void;
+  activity: OutputActivity | null;
+  activities: OutputActivity[];
+  projectId: number;
+  output: Output;
+}
+
+export default function OutputActivityForm({
+  isOpen,
+  onClose,
+  activity,
+  activities,
+  projectId,
+  output,
+}: OutputActivityFormProps) {
+  const [description, setDescription] = useState(
+    activity?.activity_description || '',
+  );
+
+  const [status, setStatus] = useState(
+    activity?.activity_status || 'Not started',
+  );
+
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    setDescription(activity?.activity_description || '');
+    setStatus(activity?.activity_status || 'Not started');
+  }, [activity]);
+
+  const mutation = useMutation({
+    mutationFn: (newActivity: Partial<OutputActivity>) =>
+      upsertOutputActivity(newActivity),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['logframe'] });
+      onClose();
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const nextActivityNumber = activity?.id
+      ? undefined
+      : (activities.length + 1).toString().padStart(2, '0');
+
+    mutation.mutate({
+      id: activity?.id,
+      activity_code: activity?.activity_code || `A${nextActivityNumber}`,
+      activity_description: description,
+      activity_status: status,
+      output_id: output.id,
+      project_id: projectId,
+    });
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className='flex max-h-[90vh] flex-col gap-4 overflow-y-auto'>
+        <DialogHeader>
+          <DialogTitle>
+            {activity ? 'Edit Activity' : 'Add Activity'}
+          </DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className='flex flex-col gap-4'>
+          <div>
+            <label
+              htmlFor='description'
+              className='mb-1 block text-sm font-medium'
+            >
+              Description
+            </label>
+            <textarea
+              id='description'
+              className='min-h-24 w-full rounded-md border bg-background px-4 py-2'
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder='Enter activity description'
+            />
+          </div>
+          <div>
+            <label htmlFor='status' className='mb-1 block text-sm font-medium'>
+              Status
+            </label>
+            <select
+              id='status'
+              className='w-full rounded-md border bg-background px-4 py-2'
+              value={status}
+              onChange={(e) => setStatus(e.target.value)}
+            >
+              <option value='Not started'>Not Started</option>
+              <option value='Delayed'>Delayed</option>
+              <option value='In progress'>In Progress</option>
+              <option value='Complete'>Complete</option>
+              <option value='Abandoned'>Abandoned</option>
+            </select>
+          </div>
+          <div className='flex justify-end'>
+            <button
+              className='flex items-center gap-2 rounded-md border border-blue-400 bg-blue-600 px-3 py-1 text-foreground transition-all hover:bg-blue-700'
+              type='submit'
+              disabled={mutation.isPending}
+            >
+              {mutation.isPending ? 'Submitting...' : 'Submit'}
+            </button>
+          </div>
+        </form>
+        <div className='mt-16 flex flex-col gap-4 text-sm text-foreground/90'>
+          <CalloutCard
+            variant='info'
+            label='Activities'
+            content={logframeText.activity.description}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/logframe/output-activity-form.tsx
+++ b/components/logframe/output-activity-form.tsx
@@ -9,21 +9,21 @@ import { upsertOutputActivity } from './server-actions';
 import { logframeText } from './logframe-text';
 
 interface OutputActivityFormProps {
+  activities: OutputActivity[];
+  activity: OutputActivity | null;
   isOpen: boolean;
   onClose: () => void;
-  activity: OutputActivity | null;
-  activities: OutputActivity[];
-  projectId: number;
   output: Output;
+  projectId: number;
 }
 
 export default function OutputActivityForm({
+  activities,
+  activity,
   isOpen,
   onClose,
-  activity,
-  activities,
-  projectId,
   output,
+  projectId,
 }: OutputActivityFormProps) {
   const [description, setDescription] = useState(
     activity?.activity_description || '',
@@ -35,6 +35,12 @@ export default function OutputActivityForm({
 
   const queryClient = useQueryClient();
 
+  const handleClose = () => {
+    setDescription('');
+    setStatus('Not started');
+    onClose();
+  };
+
   useEffect(() => {
     setDescription(activity?.activity_description || '');
     setStatus(activity?.activity_status || 'Not started');
@@ -45,7 +51,7 @@ export default function OutputActivityForm({
       upsertOutputActivity(newActivity),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['logframe'] });
-      onClose();
+      handleClose();
     },
   });
 
@@ -66,7 +72,7 @@ export default function OutputActivityForm({
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
+    <Dialog open={isOpen} onOpenChange={handleClose}>
       <DialogContent className='flex max-h-[90vh] flex-col gap-4 overflow-y-auto'>
         <DialogHeader>
           <DialogTitle>

--- a/components/logframe/output-card-logframe.tsx
+++ b/components/logframe/output-card-logframe.tsx
@@ -141,7 +141,7 @@ export default function OutputCardLogframe({
                 <div
                   className={`overflow-hidden transition-all duration-300 ease-in-out ${
                     isActivitiesExpanded
-                      ? 'max-h-[1000px] opacity-100'
+                      ? 'max-h-none opacity-100'
                       : 'max-h-0 opacity-0'
                   }`}
                 >

--- a/components/logframe/output-card-logframe.tsx
+++ b/components/logframe/output-card-logframe.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Output } from '@/utils/types';
+import { Output, OutputActivity } from '@/utils/types';
 import ActionButton from '@/components/ui/action-button';
 import FeatureCardLogframe from './feature-card-logframe';
 import OutputForm from './output-form';
@@ -10,8 +10,16 @@ import { logframeText } from './logframe-text';
 import AddOutputButton from './add-output-button';
 import { isUnplannedOutput } from './isUnplannedOutput';
 import OutputIndicatorsDetailsTable from './output-indicators-table';
-import { ChevronDown, ChevronRight } from 'lucide-react';
+import { ChevronDown, ChevronRight, Info } from 'lucide-react';
 import { Badge, BadgeProps } from '../ui/badge';
+import OutputActivityForm from './output-activity-form';
+import { extractOutputActivityCodeNumber } from './extractOutputActivityCodeNumber';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '../ui/tooltip';
 
 export default function OutputCardLogframe({
   canEdit = false,
@@ -25,6 +33,16 @@ export default function OutputCardLogframe({
 }) {
   const [isOutputDialogOpen, setIsOutputDialogOpen] = useState(false);
   const [isTableExpanded, setIsTableExpanded] = useState(true);
+  const [isActivitiesExpanded, setIsActivitiesExpanded] = useState(false);
+  const [isActivityDialogOpen, setIsActivityDialogOpen] = useState(false);
+  const [selectedActivity, setSelectedActivity] =
+    useState<OutputActivity | null>(null);
+
+  const activities = output?.activities?.sort(
+    (a, b) =>
+      extractOutputActivityCodeNumber(a.activity_code) -
+      extractOutputActivityCodeNumber(b.activity_code),
+  );
 
   return (
     <div className='relative flex flex-col gap-8'>
@@ -109,6 +127,109 @@ export default function OutputCardLogframe({
                     projectId={projectId}
                   />
                 </div>
+                <button
+                  onClick={() => setIsActivitiesExpanded(!isActivitiesExpanded)}
+                  className='my-4 flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground'
+                >
+                  {isActivitiesExpanded ? (
+                    <>
+                      <ChevronDown className='h-4 w-4 transition-transform duration-200' />{' '}
+                      Hide activities
+                    </>
+                  ) : (
+                    <>
+                      <ChevronRight className='h-4 w-4 transition-transform duration-200' />{' '}
+                      Show activities
+                    </>
+                  )}
+                </button>
+                <div
+                  className={`overflow-hidden transition-all duration-300 ease-in-out ${
+                    isActivitiesExpanded
+                      ? 'max-h-[1000px] opacity-100'
+                      : 'max-h-0 opacity-0'
+                  }`}
+                >
+                  <div className='flex flex-col gap-4'>
+                    {activities && activities.length > 0 ? (
+                      <div>
+                        <div className='rounded-md border bg-card p-4'>
+                          <div className='flex items-center gap-2'>
+                            <p className='font-medium text-muted-foreground'>
+                              Activities
+                            </p>
+
+                            <TooltipProvider>
+                              <Tooltip>
+                                <TooltipTrigger>
+                                  <Info className='h-4 w-4 text-white/60 hover:text-white' />
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                  <p className='max-w-xs text-sm'>
+                                    {logframeText.activity.description}
+                                  </p>
+                                </TooltipContent>
+                              </Tooltip>
+                            </TooltipProvider>
+                          </div>
+                          <ol className='mt-2 list-none'>
+                            {activities.map((activity) => (
+                              <li key={activity.id} className='my-4'>
+                                <div className='flex items-start gap-4'>
+                                  <ActionButton
+                                    action='edit'
+                                    variant='icon'
+                                    onClick={() => {
+                                      setSelectedActivity(activity);
+                                      setIsActivityDialogOpen(true);
+                                    }}
+                                  />
+
+                                  <span className='text-sm'>
+                                    {`${extractOutputActivityCodeNumber(
+                                      activity.activity_code,
+                                    )}.`}
+                                  </span>
+                                  <span className='max-w-prose text-sm'>
+                                    {activity.activity_description}
+                                  </span>
+                                  {activity.activity_status && (
+                                    <Badge
+                                      variant={
+                                        activity.activity_status
+                                          .toLowerCase()
+                                          .replace(
+                                            ' ',
+                                            '_',
+                                          ) as BadgeProps['variant']
+                                      }
+                                    >
+                                      {activity.activity_status}
+                                    </Badge>
+                                  )}
+                                </div>
+                              </li>
+                            ))}
+                          </ol>
+                        </div>
+                        <ActionButton
+                          action='add'
+                          label='Add activity'
+                          onClick={() => setIsActivityDialogOpen(true)}
+                          className='mt-6'
+                        />
+                      </div>
+                    ) : (
+                      <div className='mt-2 flex items-center justify-center rounded-md border border-dashed p-12'>
+                        <ActionButton
+                          action='add'
+                          label='Add activity'
+                          onClick={() => setIsActivityDialogOpen(true)}
+                        />
+                      </div>
+                    )}
+                  </div>
+                </div>
               </div>
             </div>
             <OutputForm
@@ -116,6 +237,17 @@ export default function OutputCardLogframe({
               onClose={() => setIsOutputDialogOpen(false)}
               output={output}
               projectId={projectId}
+            />
+            <OutputActivityForm
+              isOpen={isActivityDialogOpen}
+              onClose={() => {
+                setIsActivityDialogOpen(false);
+                setSelectedActivity(null);
+              }}
+              activity={selectedActivity}
+              activities={activities || []}
+              projectId={projectId}
+              output={output}
             />
           </FeatureCardLogframe>
         </div>

--- a/components/logframe/output-card-logframe.tsx
+++ b/components/logframe/output-card-logframe.tsx
@@ -124,7 +124,7 @@ export default function OutputCardLogframe({
                 </div>
                 <button
                   onClick={() => setIsActivitiesExpanded(!isActivitiesExpanded)}
-                  className='my-4 flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground'
+                  className='my-6 flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground'
                 >
                   {isActivitiesExpanded ? (
                     <>

--- a/components/logframe/output-card-logframe.tsx
+++ b/components/logframe/output-card-logframe.tsx
@@ -10,16 +10,11 @@ import { logframeText } from './logframe-text';
 import AddOutputButton from './add-output-button';
 import { isUnplannedOutput } from './isUnplannedOutput';
 import OutputIndicatorsDetailsTable from './output-indicators-table';
-import { ChevronDown, ChevronRight, Info } from 'lucide-react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
 import { Badge, BadgeProps } from '../ui/badge';
 import OutputActivityForm from './output-activity-form';
 import { extractOutputActivityCodeNumber } from './extractOutputActivityCodeNumber';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '../ui/tooltip';
+import OutputActivitiesList from './output-activities-list';
 
 export default function OutputCardLogframe({
   canEdit = false,
@@ -150,85 +145,13 @@ export default function OutputCardLogframe({
                       : 'max-h-0 opacity-0'
                   }`}
                 >
-                  <div className='flex flex-col gap-4'>
-                    {activities && activities.length > 0 ? (
-                      <div>
-                        <div className='rounded-md border bg-card p-4'>
-                          <div className='flex items-center gap-2'>
-                            <p className='font-medium text-muted-foreground'>
-                              Activities
-                            </p>
-
-                            <TooltipProvider>
-                              <Tooltip>
-                                <TooltipTrigger>
-                                  <Info className='h-4 w-4 text-white/60 hover:text-white' />
-                                </TooltipTrigger>
-                                <TooltipContent>
-                                  <p className='max-w-xs text-sm'>
-                                    {logframeText.activity.description}
-                                  </p>
-                                </TooltipContent>
-                              </Tooltip>
-                            </TooltipProvider>
-                          </div>
-                          <ol className='mt-2 list-none'>
-                            {activities.map((activity) => (
-                              <li key={activity.id} className='my-4'>
-                                <div className='flex items-start gap-4'>
-                                  <ActionButton
-                                    action='edit'
-                                    variant='icon'
-                                    onClick={() => {
-                                      setSelectedActivity(activity);
-                                      setIsActivityDialogOpen(true);
-                                    }}
-                                  />
-
-                                  <span className='text-sm'>
-                                    {`${extractOutputActivityCodeNumber(
-                                      activity.activity_code,
-                                    )}.`}
-                                  </span>
-                                  <span className='max-w-prose text-sm'>
-                                    {activity.activity_description}
-                                  </span>
-                                  {activity.activity_status && (
-                                    <Badge
-                                      variant={
-                                        activity.activity_status
-                                          .toLowerCase()
-                                          .replace(
-                                            ' ',
-                                            '_',
-                                          ) as BadgeProps['variant']
-                                      }
-                                    >
-                                      {activity.activity_status}
-                                    </Badge>
-                                  )}
-                                </div>
-                              </li>
-                            ))}
-                          </ol>
-                        </div>
-                        <ActionButton
-                          action='add'
-                          label='Add activity'
-                          onClick={() => setIsActivityDialogOpen(true)}
-                          className='mt-6'
-                        />
-                      </div>
-                    ) : (
-                      <div className='mt-2 flex items-center justify-center rounded-md border border-dashed p-12'>
-                        <ActionButton
-                          action='add'
-                          label='Add activity'
-                          onClick={() => setIsActivityDialogOpen(true)}
-                        />
-                      </div>
-                    )}
-                  </div>
+                  {activities && output && (
+                    <OutputActivitiesList
+                      activities={activities}
+                      output={output}
+                      projectId={projectId}
+                    />
+                  )}
                 </div>
               </div>
             </div>

--- a/components/logframe/output-indicators-table.tsx
+++ b/components/logframe/output-indicators-table.tsx
@@ -83,7 +83,7 @@ export default function OutputIndicatorsDetailsTable({
   return (
     <>
       {measurables.length === 0 ? (
-        <div className='flex items-center justify-center rounded-md border border-dashed p-12'>
+        <div className='mb-8 flex items-center justify-center rounded-md border border-dashed p-12'>
           <ActionButton
             action='add'
             label='Add output indicator'

--- a/components/logframe/output-indicators-table.tsx
+++ b/components/logframe/output-indicators-table.tsx
@@ -83,7 +83,7 @@ export default function OutputIndicatorsDetailsTable({
   return (
     <>
       {measurables.length === 0 ? (
-        <div className='mb-8 flex items-center justify-center rounded-md border border-dashed p-12'>
+        <div className='flex items-center justify-center rounded-md border border-dashed p-12'>
           <ActionButton
             action='add'
             label='Add output indicator'

--- a/components/logframe/server-actions.ts
+++ b/components/logframe/server-actions.ts
@@ -313,7 +313,6 @@ export const upsertOutputActivity = async (
 ) => {
   const supabase = await createClient();
 
-  // TODO: can we make the activity associated with the Output instead of output indicator?
   if (!activity.activity_description || !activity.output_id) {
     throw new Error('Missing required fields');
   }

--- a/components/logframe/server-actions.ts
+++ b/components/logframe/server-actions.ts
@@ -6,6 +6,7 @@ import {
   Outcome,
   OutcomeMeasurable,
   Output,
+  OutputActivity,
   OutputMeasurable,
 } from '@/utils/types';
 
@@ -14,7 +15,7 @@ export const fetchLogframe = async (identifier: number | string) => {
   const response = await supabase
     .from('projects')
     .select(
-      'id, slug, name, impacts(*), outcomes(*, outcome_measurables(*, impact_indicators(*))), outputs(*, output_measurables(*, impact_indicators(*), updates(*)))',
+      'id, slug, name, impacts(*), outcomes(*, outcome_measurables(*, impact_indicators(*))), outputs(*, activities(*), output_measurables(*, impact_indicators(*), updates(*)))',
     )
     .eq(typeof identifier === 'number' ? 'id' : 'slug', identifier)
     .single();
@@ -38,7 +39,7 @@ export const fetchUnassignedOutputs = async (identifier: number | string) => {
   const response = await supabase
     .from('projects')
     .select(
-      'id, slug, name,  outputs!inner(*, output_measurables(*, impact_indicators(*), updates(*)))',
+      'id, slug, name, outputs!inner(*, activities(*), output_measurables(*, impact_indicators(*), updates(*)))',
     )
     .eq(typeof identifier === 'number' ? 'id' : 'slug', identifier)
     .is('outputs.outcome_measurable_id', null)
@@ -306,3 +307,32 @@ export async function fetchOutcomeMeasurables(projectId: number) {
   if (error) throw error;
   return data;
 }
+
+export const upsertOutputActivity = async (
+  activity: Partial<OutputActivity>,
+) => {
+  const supabase = await createClient();
+
+  // TODO: can we make the activity associated with the Output instead of output indicator?
+  if (!activity.activity_description || !activity.output_id) {
+    throw new Error('Missing required fields');
+  }
+
+  const reqBody = {
+    id: activity.id,
+    activity_code: activity.activity_code,
+    activity_description: activity.activity_description,
+    activity_status: activity.activity_status,
+    output_id: activity.output_id,
+    project_id: activity.project_id,
+  };
+
+  const { data, error } = await supabase
+    .from('activities')
+    .upsert(reqBody)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+};

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -83,6 +83,7 @@ export interface Output {
   description: string;
   status: string;
   output_measurables?: OutputMeasurable[];
+  activities?: OutputActivity[];
 }
 
 export interface OutputMeasurable {
@@ -129,4 +130,14 @@ export type User = {
   id: string;
   first_name: string;
   last_name: string;
+};
+
+export type OutputActivity = {
+  id: number;
+  activity_code: string;
+  activity_description: string;
+  activity_status: string;
+  created_at: string;
+  output_id: number;
+  project_id: number;
 };


### PR DESCRIPTION
### Changes
- https://github.com/Blue-Marine-Foundation/Maerl/issues/142 On the Logframe page, in each Output card, enable the user to add and edit a numbered Activities list related to that Output 

### Screenshots
Empty state:
<img width="1348" alt="Screenshot 2025-03-11 at 6 44 03 PM" src="https://github.com/user-attachments/assets/b4ec318f-df9c-4d6d-97a1-836fd5604c7f" />

<img width="733" alt="Screenshot 2025-03-11 at 6 44 10 PM" src="https://github.com/user-attachments/assets/70b9cb7f-9ca4-49f0-b76b-05507f9fdc4a" />

<img width="1356" alt="Screenshot 2025-03-11 at 6 43 43 PM" src="https://github.com/user-attachments/assets/3a984b30-f84f-4f2f-a098-3c80aba0eac5" />

