### PR TITLE
Fix bug for PMs logging into projects with no data

### DIFF
--- a/components/updates/updates-list-medium.tsx
+++ b/components/updates/updates-list-medium.tsx
@@ -3,8 +3,6 @@ import Link from 'next/link';
 import * as d3 from 'd3';
 
 export default function UpdatesListMedium({ updates }: { updates: Update[] }) {
-  console.log(updates[0].projects);
-
   return (
     <div className='flex flex-col'>
       {updates?.map((update) => (


### PR DESCRIPTION
A tiny bug threw an error when a PM tried to log in but the project had no updates. There would have needed to be a quite specific set of circumstances to trigger the error: 

- The user must have been assigned as a Project Manager rather than Admin 
- The user must have been assigned to only projects with zero updates 