### PR TITLE
Introduce partner role access and output-level RLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-To run the app locally: 
+## Running locally
 
 - Clone the repo
-- Add an .env.local file with the two environment variables
-- From the root of the repo run the following commands:
-  - npm install
-  - npx next dev
-- The development server should start at localhost:3000
+- Create an env file (`.env.local` recommended) with:
+  - `NEXT_PUBLIC_SUPABASE_URL`
+  - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+  - `NEXT_PUBLIC_SUPABASE_SERVICE_ROLE` (only needed for scripts/routes that use the service-role client)
+- Install deps + run dev server (this repo uses **pnpm**):
+  - `corepack enable`
+  - `corepack prepare pnpm@10.25.0 --activate`
+  - `pnpm install`
+  - `pnpm dev`
+- The development server should start at `http://localhost:3000`

--- a/api/fetch-current-user-profile.ts
+++ b/api/fetch-current-user-profile.ts
@@ -1,0 +1,52 @@
+'use server';
+
+import { createClient } from '@/utils/supabase/server';
+
+export type AppUserRole = 'Admin' | 'Project Manager' | 'Partner';
+
+export type UserProfile = {
+  id: string;
+  first_name: string | null;
+  last_name: string | null;
+  role: AppUserRole | null;
+};
+
+export type CurrentUserProfileResponse =
+  | {
+      authUser: {
+        id: string;
+        email?: string | null;
+      };
+      profile: UserProfile | null;
+    }
+  | {
+      authUser: null;
+      profile: null;
+    };
+
+export async function fetchCurrentUserProfile(): Promise<CurrentUserProfileResponse> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { authUser: null, profile: null };
+  }
+
+  const { data: profile } = await supabase
+    .from('users')
+    .select('id, first_name, last_name, role')
+    .eq('id', user.id)
+    .maybeSingle();
+
+  return {
+    authUser: {
+      id: user.id,
+      email: user.email,
+    },
+    profile: profile ?? null,
+  };
+}
+

--- a/app/(protected)/admin/layout.tsx
+++ b/app/(protected)/admin/layout.tsx
@@ -1,0 +1,11 @@
+import { requireNonPartner } from '@/utils/auth/guards';
+
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  await requireNonPartner('/projects');
+  return children;
+}
+

--- a/app/(protected)/impactindicators/layout.tsx
+++ b/app/(protected)/impactindicators/layout.tsx
@@ -1,0 +1,11 @@
+import { requireNonPartner } from '@/utils/auth/guards';
+
+export default async function ImpactIndicatorsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  await requireNonPartner('/projects');
+  return children;
+}
+

--- a/app/(protected)/projects/[slug]/archive/layout.tsx
+++ b/app/(protected)/projects/[slug]/archive/layout.tsx
@@ -1,0 +1,11 @@
+import { requireNonPartner } from '@/utils/auth/guards';
+
+export default async function ProjectArchiveLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  await requireNonPartner('/projects');
+  return children;
+}
+

--- a/app/(protected)/projects/[slug]/impact/layout.tsx
+++ b/app/(protected)/projects/[slug]/impact/layout.tsx
@@ -1,0 +1,11 @@
+import { requireNonPartner } from '@/utils/auth/guards';
+
+export default async function ProjectImpactLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  await requireNonPartner('/projects');
+  return children;
+}
+

--- a/app/(protected)/projects/[slug]/logframe/page.tsx
+++ b/app/(protected)/projects/[slug]/logframe/page.tsx
@@ -13,9 +13,11 @@ import ImpactCardLogframe from '@/components/logframe/impact-card-logframe';
 import LogframeQuickNav from '@/components/logframe/quick-nav';
 import FeatureCardLogframe from '@/components/logframe/feature-card-logframe';
 import { useLogframeDeeplinking } from './useLogframeDeeplinking';
+import { useUser } from '@/components/user/user-provider';
 
 export default function LogframePage() {
   const { slug } = useParams();
+  const { canEditLogframe } = useUser();
 
   const { data, isLoading } = useQuery({
     queryKey: ['logframe', slug],
@@ -46,7 +48,7 @@ export default function LogframePage() {
     const getPrefix = (code: string) => code?.split('.')[0] || '';
     const getNum = (code: string) => {
       const match = code?.match(/\.(\d+)$/);
-      return match ? parseInt(match[1]) : Infinity;
+      return match ? Number.parseInt(match[1], 10) : Number.POSITIVE_INFINITY;
     };
     const prefixA = getPrefix(a.code);
     const prefixB = getPrefix(b.code);
@@ -54,7 +56,7 @@ export default function LogframePage() {
       return prefixA.localeCompare(prefixB);
     }
     return getNum(a.code) - getNum(b.code);
-  }).filter((output) => !output.archived)
+  }).filter((output) => !output.archived);
   const projectId = data?.data?.id;
 
   return (
@@ -64,7 +66,11 @@ export default function LogframePage() {
       )}
       <div className='flex flex-col gap-8'>
         <div id='impact' className='mt-4'>
-          <ImpactCardLogframe impact={impact} projectId={projectId} canEdit />
+          <ImpactCardLogframe
+            impact={impact}
+            projectId={projectId}
+            canEdit={canEditLogframe}
+          />
         </div>
         <div className='flex flex-col gap-8'>
           {outcomes.map((outcome) => (
@@ -73,12 +79,16 @@ export default function LogframePage() {
                 outcome={outcome}
                 outcomes={outcomes}
                 projectId={projectId}
-                canEdit
+                canEdit={canEditLogframe}
               />
             </div>
           ))}
           {outcomes.length === 0 && (
-            <OutcomeCardLogframe outcome={null} projectId={projectId} canEdit />
+            <OutcomeCardLogframe
+              outcome={null}
+              projectId={projectId}
+              canEdit={canEditLogframe}
+            />
           )}
         </div>
         <div className='flex flex-col gap-8'>
@@ -89,11 +99,11 @@ export default function LogframePage() {
                   output={output}
                   projectId={projectId}
                   projectSlug={slug as string}
-                  canEdit
+                  canEdit={canEditLogframe}
                 />
               </div>
             ))}
-          {allOutputs.length > 0 && (
+          {canEditLogframe && allOutputs.length > 0 && (
             <div className='mt-4'>
               <AddOutputButton
                 projectId={projectId}
@@ -105,11 +115,17 @@ export default function LogframePage() {
           {allOutputs.length === 0 && (
             <FeatureCardLogframe title='Outputs' variant='output'>
               <div className='mt-4'>
-                <AddOutputButton
-                  projectId={projectId}
-                  output={null}
-                  existingCodes={allOutputs.map((o) => o.code)}
-                />
+                {canEditLogframe ? (
+                  <AddOutputButton
+                    projectId={projectId}
+                    output={null}
+                    existingCodes={allOutputs.map((o) => o.code)}
+                  />
+                ) : (
+                  <p className='text-sm text-muted-foreground'>
+                    No outputs yet.
+                  </p>
+                )}
               </div>
             </FeatureCardLogframe>
           )}

--- a/app/(protected)/projects/[slug]/theory-of-change/page.tsx
+++ b/app/(protected)/projects/[slug]/theory-of-change/page.tsx
@@ -9,9 +9,11 @@ import TheoryOfChangeSkeleton from '@/components/logframe/theory-of-change-skele
 import OutputsContainer from '@/components/logframe/outputs-container';
 import LogframeQuickNav from '@/components/logframe/quick-nav';
 import { extractOutputCodeNumber } from '@/components/logframe/extractOutputCodeNumber';
+import { useUser } from '@/components/user/user-provider';
 
 export default function TheoryOfChangePage() {
   const { slug } = useParams();
+  const { canEditLogframe } = useUser();
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['logframe', slug],
@@ -45,7 +47,11 @@ export default function TheoryOfChangePage() {
       <LogframeQuickNav outcomes={outcomes} outputs={outputs} />
       <div className='flex flex-col gap-8'>
         <div className='mt-4' id='impact'>
-          <ImpactCard impact={impact} projectId={projectId} canEdit={!impact} />
+          <ImpactCard
+            impact={impact}
+            projectId={projectId}
+            canEdit={canEditLogframe && !impact}
+          />
         </div>
         <div className='mx-16 flex flex-col gap-8'>
           {outcomes.map((outcome) => (
@@ -55,17 +61,26 @@ export default function TheoryOfChangePage() {
                 outcome={outcome}
                 outcomes={outcomes}
                 projectId={projectId}
+                canEdit={canEditLogframe}
               />
             </div>
           ))}
           {outcomes.length === 0 && (
-            <OutcomeCard outcome={null} projectId={projectId} canEdit />
+            <OutcomeCard
+              outcome={null}
+              projectId={projectId}
+              canEdit={canEditLogframe}
+            />
           )}
         </div>
         <div>
           {
             <div className='mx-32 flex flex-col gap-8'>
-              <OutputsContainer outputs={outputs} projectId={projectId} />
+              <OutputsContainer
+                outputs={outputs}
+                projectId={projectId}
+                canEdit={canEditLogframe}
+              />
             </div>
           }
         </div>

--- a/app/(protected)/projects/[slug]/updates/layout.tsx
+++ b/app/(protected)/projects/[slug]/updates/layout.tsx
@@ -1,0 +1,11 @@
+import { requireNonPartner } from '@/utils/auth/guards';
+
+export default async function ProjectUpdatesLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  await requireNonPartner('/projects');
+  return children;
+}
+

--- a/app/(protected)/updates/layout.tsx
+++ b/app/(protected)/updates/layout.tsx
@@ -1,0 +1,11 @@
+import { requireNonPartner } from '@/utils/auth/guards';
+
+export default async function UpdatesLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  await requireNonPartner('/projects');
+  return children;
+}
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,7 @@ import Footer from '@/components/footer/footer';
 import QueryProvider from '@/utils/query-provider';
 import { Toaster } from 'sonner';
 import { Analytics } from '@vercel/analytics/next';
-import { UserProvider } from '@/components/user/user-provider';
+import { UserSessionSync } from '@/components/user/user-provider';
 
 const defaultUrl = process.env.VERCEL_URL
   ? `https://${process.env.VERCEL_URL}`
@@ -31,13 +31,12 @@ export default function RootLayout({
     <html lang='en' className={inter.className} suppressHydrationWarning>
       <body className='min-h-svh bg-background text-foreground dark:bg-background'>
         <QueryProvider>
-          <UserProvider>
-            <Header />
-            <div className='mb-32 px-4'>{children}</div>
-            <Footer />
-            <Toaster richColors />
-            <Analytics />
-          </UserProvider>
+          <UserSessionSync />
+          <Header />
+          <div className='mb-32 px-4'>{children}</div>
+          <Footer />
+          <Toaster richColors />
+          <Analytics />
         </QueryProvider>
       </body>
     </html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,8 +4,8 @@ import Header from '@/components/header/header';
 import Footer from '@/components/footer/footer';
 import QueryProvider from '@/utils/query-provider';
 import { Toaster } from 'sonner';
-        import { Analytics } from "@vercel/analytics/next"
-
+import { Analytics } from '@vercel/analytics/next';
+import { UserProvider } from '@/components/user/user-provider';
 
 const defaultUrl = process.env.VERCEL_URL
   ? `https://${process.env.VERCEL_URL}`
@@ -24,19 +24,21 @@ const inter = Inter({
 
 export default function RootLayout({
   children,
-}: {
+}: Readonly<{
   children: React.ReactNode;
-}) {
+}>) {
   return (
     <html lang='en' className={inter.className} suppressHydrationWarning>
       <body className='min-h-svh bg-background text-foreground dark:bg-background'>
-        <Header />
         <QueryProvider>
-          <div className='mb-32 px-4'>{children}</div>
+          <UserProvider>
+            <Header />
+            <div className='mb-32 px-4'>{children}</div>
+            <Footer />
+            <Toaster richColors />
+            <Analytics />
+          </UserProvider>
         </QueryProvider>
-        <Footer />
-        <Toaster richColors />
-        <Analytics />
       </body>
     </html>
   );

--- a/components/header/primary-nav.tsx
+++ b/components/header/primary-nav.tsx
@@ -2,6 +2,7 @@
 import { usePathname, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { extractDateParams } from '@/utils/date-utils';
+import { useUser } from '@/components/user/user-provider';
 
 interface NavItem {
   name: string;
@@ -11,40 +12,53 @@ interface NavItem {
 export default function PrimaryNavigation() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const { isPartner } = useUser();
 
   // Only preserve date params
   const dateParams = extractDateParams(searchParams);
   const hasDateParams = dateParams.toString().length > 0;
 
   const items = [
-    {
-      name: 'Overview',
-      href: '/',
-    },
+    ...(isPartner
+      ? []
+      : [
+          {
+            name: 'Overview',
+            href: '/',
+          },
+        ]),
     {
       name: 'Projects',
       href: '/projects',
     },
-    {
-      name: 'Impact Indicators',
-      href: '/impactindicators',
-    },
-    {
-      name: 'Updates',
-      href: '/updates',
-    },
+    ...(isPartner
+      ? []
+      : [
+          {
+            name: 'Impact Indicators',
+            href: '/impactindicators',
+          },
+          {
+            name: 'Updates',
+            href: '/updates',
+          },
+        ]),
   ];
 
   return (
     <ul className='flex w-full gap-1 text-sm'>
       {items.map((item: NavItem) => {
+        const href = hasDateParams
+          ? `${item.href}?${dateParams.toString()}`
+          : item.href;
+
         return (
           <li
             key={item.name}
             className={` ${pathname === item.href && 'active'} group inline-block leading-4 transition-all`}
           >
             <Link
-              href={`${item.href}${hasDateParams ? `?${dateParams.toString()}` : ''}`}
+              href={href}
               className='inline-block rounded-md border border-transparent px-4 py-2 text-foreground/80 transition-all ease-in-out hover:border-foreground/20 group-[.active]:border-slate-800 group-[.active]:bg-sky-800/50 group-[.active]:text-foreground'
             >
               {item.name}

--- a/components/header/primary-nav.tsx
+++ b/components/header/primary-nav.tsx
@@ -12,28 +12,27 @@ interface NavItem {
 export default function PrimaryNavigation() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const { isPartner } = useUser();
+  const { hasManagerAccess } = useUser();
 
   // Only preserve date params
   const dateParams = extractDateParams(searchParams);
   const hasDateParams = dateParams.toString().length > 0;
 
   const items = [
-    ...(isPartner
-      ? []
-      : [
+    ...(hasManagerAccess
+      ? [
           {
             name: 'Overview',
             href: '/',
           },
-        ]),
+        ]
+      : []),
     {
       name: 'Projects',
       href: '/projects',
     },
-    ...(isPartner
-      ? []
-      : [
+    ...(hasManagerAccess
+      ? [
           {
             name: 'Impact Indicators',
             href: '/impactindicators',
@@ -42,7 +41,8 @@ export default function PrimaryNavigation() {
             name: 'Updates',
             href: '/updates',
           },
-        ]),
+        ]
+      : []),
   ];
 
   return (

--- a/components/logframe/outcome-card-logframe.tsx
+++ b/components/logframe/outcome-card-logframe.tsx
@@ -8,20 +8,19 @@ import ActionButton from '@/components/ui/action-button';
 import FeatureCardLogframe from './feature-card-logframe';
 import OutcomeIndicatorsTable from './outcome-indicators-table';
 import { extractOutputCodeNumber } from './extractOutputCodeNumber';
-import { logframeText } from './logframe-text';
 
 export default function OutcomeCardLogframe({
   canEdit = false,
   outcome,
   outcomes,
   projectId,
-}: {
+}: Readonly<{
   /** Enables the Add Impact and Edit Impact buttons*/
   canEdit?: boolean;
   outcome: Outcome | null;
   outcomes?: Outcome[];
   projectId: number;
-}) {
+}>) {
   const [isOutcomeDialogOpen, setIsOutcomeDialogOpen] = useState(false);
   const [isTableExpanded, setIsTableExpanded] = useState(true);
 
@@ -53,66 +52,65 @@ export default function OutcomeCardLogframe({
       )}
 
       {outcomes && outcome && (
-        <>
-          <FeatureCardLogframe
-            title={
-              outcomes.length > 1
-                ? `Outcome ${extractOutputCodeNumber(outcome.code)}`
-                : 'Outcome'
-            }
-            variant='outcome'
-            minHeight='100%'
-          >
-            <div className='flex w-full grow flex-col items-start justify-between gap-6'>
-              <div className='flex w-full flex-row items-center justify-between'>
-                <p className='max-w-prose text-sm'>{outcome.description}</p>
-                {canEdit && (
-                  <div className='flex-shrink-0 text-sm'>
-                    <ActionButton
-                      action='edit'
-                      onClick={() => setIsOutcomeDialogOpen(true)}
-                    />
-                  </div>
-                )}
-              </div>
-              <div className='w-full'>
-                <button
-                  onClick={() => setIsTableExpanded(!isTableExpanded)}
-                  className='mb-4 flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground'
-                >
-                  {isTableExpanded ? (
-                    <>
-                      <ChevronDown className='h-4 w-4 transition-transform duration-200' />{' '}
-                      Hide indicators
-                    </>
-                  ) : (
-                    <>
-                      <ChevronRight className='h-4 w-4 transition-transform duration-200' />{' '}
-                      Show indicators
-                    </>
-                  )}
-                </button>
-                <div
-                  className={`overflow-hidden transition-all duration-300 ease-in-out ${isTableExpanded ? 'max-h-[1000px] opacity-100' : 'max-h-0 opacity-0'}`}
-                >
-                  <OutcomeIndicatorsTable
-                    measurables={outcomeMeasurables}
-                    outcomeId={outcome.id}
-                    projectId={projectId}
+        <FeatureCardLogframe
+          title={
+            outcomes.length > 1
+              ? `Outcome ${extractOutputCodeNumber(outcome.code)}`
+              : 'Outcome'
+          }
+          variant='outcome'
+          minHeight='100%'
+        >
+          <div className='flex w-full grow flex-col items-start justify-between gap-6'>
+            <div className='flex w-full flex-row items-center justify-between'>
+              <p className='max-w-prose text-sm'>{outcome.description}</p>
+              {canEdit && (
+                <div className='flex-shrink-0 text-sm'>
+                  <ActionButton
+                    action='edit'
+                    onClick={() => setIsOutcomeDialogOpen(true)}
                   />
                 </div>
+              )}
+            </div>
+            <div className='w-full'>
+              <button
+                onClick={() => setIsTableExpanded(!isTableExpanded)}
+                className='mb-4 flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground'
+              >
+                {isTableExpanded ? (
+                  <>
+                    <ChevronDown className='h-4 w-4 transition-transform duration-200' />{' '}
+                    Hide indicators
+                  </>
+                ) : (
+                  <>
+                    <ChevronRight className='h-4 w-4 transition-transform duration-200' />{' '}
+                    Show indicators
+                  </>
+                )}
+              </button>
+              <div
+                className={`overflow-hidden transition-all duration-300 ease-in-out ${isTableExpanded ? 'max-h-[1000px] opacity-100' : 'max-h-0 opacity-0'}`}
+              >
+                <OutcomeIndicatorsTable
+                  measurables={outcomeMeasurables}
+                  outcomeId={outcome.id}
+                  projectId={projectId}
+                  canEdit={canEdit}
+                />
               </div>
             </div>
+          </div>
 
-            <OutcomeForm
-              isOpen={isOutcomeDialogOpen}
-              onClose={() => setIsOutcomeDialogOpen(false)}
-              outcome={outcome}
-              projectId={projectId}
-              existingCodes={outcomes?.map((o) => o.code) || []}
-            />
-          </FeatureCardLogframe>
-        </>
+          <OutcomeForm
+            isOpen={isOutcomeDialogOpen}
+            onClose={() => setIsOutcomeDialogOpen(false)}
+            outcome={outcome}
+            projectId={projectId}
+            existingCodes={outcomes?.map((o) => o.code) || []}
+          />
+        </FeatureCardLogframe>
       )}
     </div>
   );

--- a/components/logframe/output-activities-list.tsx
+++ b/components/logframe/output-activities-list.tsx
@@ -19,13 +19,15 @@ interface OutputActivitiesListProps {
   activities: OutputActivity[];
   output: Output;
   projectId: number;
+  canEdit?: boolean;
 }
 
 export default function OutputActivitiesList({
   activities,
   output,
   projectId,
-}: OutputActivitiesListProps) {
+  canEdit = true,
+}: Readonly<OutputActivitiesListProps>) {
   const [isActivityDialogOpen, setIsActivityDialogOpen] = useState(false);
   const [selectedActivity, setSelectedActivity] =
     useState<OutputActivity | null>(null);
@@ -54,14 +56,16 @@ export default function OutputActivitiesList({
               {activities.map((activity) => (
                 <li key={activity.id} className='my-4'>
                   <div className='flex items-start gap-4'>
-                    <ActionButton
-                      action='edit'
-                      variant='icon'
-                      onClick={() => {
-                        setSelectedActivity(activity);
-                        setIsActivityDialogOpen(true);
-                      }}
-                    />
+                    {canEdit && (
+                      <ActionButton
+                        action='edit'
+                        variant='icon'
+                        onClick={() => {
+                          setSelectedActivity(activity);
+                          setIsActivityDialogOpen(true);
+                        }}
+                      />
+                    )}
 
                     <span className='text-sm'>
                       {`${extractOutputActivityCodeNumber(
@@ -87,34 +91,42 @@ export default function OutputActivitiesList({
               ))}
             </ol>
           </div>
-          <ActionButton
-            action='add'
-            label='Add activity'
-            onClick={() => setIsActivityDialogOpen(true)}
-            className='mt-6'
-          />
+          {canEdit && (
+            <ActionButton
+              action='add'
+              label='Add activity'
+              onClick={() => setIsActivityDialogOpen(true)}
+              className='mt-6'
+            />
+          )}
         </div>
       ) : (
         <div className='mt-2 flex items-center justify-center rounded-md border border-dashed p-12'>
-          <ActionButton
-            action='add'
-            label='Add activity'
-            onClick={() => setIsActivityDialogOpen(true)}
-          />
+          {canEdit ? (
+            <ActionButton
+              action='add'
+              label='Add activity'
+              onClick={() => setIsActivityDialogOpen(true)}
+            />
+          ) : (
+            <p className='text-sm text-muted-foreground'>No activities yet.</p>
+          )}
         </div>
       )}
 
-      <OutputActivityForm
-        isOpen={isActivityDialogOpen}
-        onClose={() => {
-          setIsActivityDialogOpen(false);
-          setSelectedActivity(null);
-        }}
-        activity={selectedActivity}
-        activities={activities}
-        projectId={projectId}
-        output={output}
-      />
+      {canEdit && (
+        <OutputActivityForm
+          isOpen={isActivityDialogOpen}
+          onClose={() => {
+            setIsActivityDialogOpen(false);
+            setSelectedActivity(null);
+          }}
+          activity={selectedActivity}
+          activities={activities}
+          projectId={projectId}
+          output={output}
+        />
+      )}
     </div>
   );
 }

--- a/components/logframe/output-card-logframe.tsx
+++ b/components/logframe/output-card-logframe.tsx
@@ -22,7 +22,7 @@ export default function OutputCardLogframe({
   projectId,
   existingCodes = [],
   showIndicator = true,
-}: {
+}: Readonly<{
   /** Enables the Add Output and Edit Output buttons*/
   canEdit?: boolean;
   output: Output | null;
@@ -30,7 +30,7 @@ export default function OutputCardLogframe({
   projectSlug: string;
   existingCodes?: string[];
   showIndicator?: boolean;
-}) {
+}>) {
   const [isOutputDialogOpen, setIsOutputDialogOpen] = useState(false);
   const [isTableExpanded, setIsTableExpanded] = useState(showIndicator);
   const [isActivitiesExpanded, setIsActivitiesExpanded] = useState(false);
@@ -91,7 +91,7 @@ export default function OutputCardLogframe({
                     className='border-foreground/80 text-sm hover:bg-foreground/10'
                   />
                 )}
-                <ArchiveToggle outputType='output' data={output} />
+                {canEdit && <ArchiveToggle outputType='output' data={output} />}
               </div>
             </div>
           </div>
@@ -127,6 +127,7 @@ export default function OutputCardLogframe({
                     outputId={output.id}
                     projectId={projectId}
                     outputCode={output.code}
+                    canEditStructure={canEdit}
                   />
                 </div>
                 <button
@@ -157,6 +158,7 @@ export default function OutputCardLogframe({
                       activities={activities}
                       output={output}
                       projectId={projectId}
+                      canEdit={canEdit}
                     />
                   )}
                 </div>
@@ -169,17 +171,19 @@ export default function OutputCardLogframe({
               projectId={projectId}
               existingCodes={existingCodes}
             />
-            <OutputActivityForm
-              isOpen={isActivityDialogOpen}
-              onClose={() => {
-                setIsActivityDialogOpen(false);
-                setSelectedActivity(null);
-              }}
-              activity={selectedActivity}
-              activities={activities || []}
-              projectId={projectId}
-              output={output}
-            />
+            {canEdit && (
+              <OutputActivityForm
+                isOpen={isActivityDialogOpen}
+                onClose={() => {
+                  setIsActivityDialogOpen(false);
+                  setSelectedActivity(null);
+                }}
+                activity={selectedActivity}
+                activities={activities || []}
+                projectId={projectId}
+                output={output}
+              />
+            )}
           </div>
         </div>
       )}

--- a/components/logframe/output-indicator-updates.tsx
+++ b/components/logframe/output-indicator-updates.tsx
@@ -84,7 +84,7 @@ export default function OutputIndicatorUpdates({
                         >
                           {update.type}
                         </Badge>
-                        {update.value ? (
+                        {update.value !== null && update.value !== undefined ? (
                           <>
                             <span className='text-xs text-muted-foreground'>
                               |

--- a/components/logframe/output-indicator-updates.tsx
+++ b/components/logframe/output-indicator-updates.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { OutputMeasurable } from '@/utils/types';
 import { Badge } from '@/components/ui/badge';
 import ActionButton from '@/components/ui/action-button';
@@ -12,12 +14,14 @@ import {
   DialogTrigger,
 } from '../ui/dialog';
 import UpdateForm from '../updates/update-form';
+import { useUser } from '@/components/user/user-provider';
 
 export default function OutputIndicatorUpdates({
   measurable,
-}: {
+}: Readonly<{
   measurable: OutputMeasurable;
-}) {
+}>) {
+  const { authUserId, isAdmin } = useUser();
   const measurableUpdates = measurable.updates
     ?.filter((update) => !update.duplicate && update.valid)
     .sort((a, b) => {
@@ -40,22 +44,26 @@ export default function OutputIndicatorUpdates({
                 >
                   <div className='flex flex-row gap-4'>
                     <div>
-                      <Dialog>
-                        <DialogTrigger asChild>
-                          <ActionButton action='edit' variant='icon' />
-                        </DialogTrigger>
-                        <DialogContent>
-                          <DialogHeader>
-                            <DialogTitle>Edit update</DialogTitle>
-                          </DialogHeader>
-                          <UpdateForm
-                            outputMeasurable={measurable}
-                            impactIndicator={measurable.impact_indicators!}
-                            projectId={measurable.project_id}
-                            update={update}
-                          />
-                        </DialogContent>
-                      </Dialog>
+                      {(isAdmin ||
+                        (authUserId && update.posted_by === authUserId)) && (
+                        <Dialog>
+                          <DialogTrigger asChild>
+                            <ActionButton action='edit' variant='icon' />
+                          </DialogTrigger>
+                          <DialogContent>
+                            <DialogHeader>
+                              <DialogTitle>Edit update</DialogTitle>
+                            </DialogHeader>
+                            <UpdateForm
+                              outputMeasurable={measurable}
+                              impactIndicator={measurable.impact_indicators!}
+                              projectId={measurable.project_id}
+                              update={update}
+                              isAdmin={isAdmin}
+                            />
+                          </DialogContent>
+                        </Dialog>
+                      )}
                     </div>
                     <div>
                       <p className='max-w-prose text-sm'>
@@ -76,7 +84,7 @@ export default function OutputIndicatorUpdates({
                         >
                           {update.type}
                         </Badge>
-                        {!!update.value ? (
+                        {update.value ? (
                           <>
                             <span className='text-xs text-muted-foreground'>
                               |

--- a/components/logframe/output-indicators-table-columns.tsx
+++ b/components/logframe/output-indicators-table-columns.tsx
@@ -17,6 +17,7 @@ export const createColumns = (
   toggleRow: (rowId: string) => void,
   expandedRows: Record<string, boolean>,
   handleEditMeasurable: (measurable: OutputMeasurable) => void,
+  canEditStructure: boolean,
   projectId: string,
 ): ColumnDef<OutputMeasurable, any>[] => [
   {
@@ -110,14 +111,16 @@ export const createColumns = (
     header: '',
     size: 70,
     cell: ({ row }: { row: any }) => (
-      <div className='flex items-center gap-2 pt-0.5'>
-        <ActionButton
-          action='edit'
-          variant='icon'
-          onClick={() => handleEditMeasurable(row.original)}
-        />
-        <ArchiveToggle outputType='output_indicator' data={row.original} />
-      </div>
+      canEditStructure ? (
+        <div className='flex items-center gap-2 pt-0.5'>
+          <ActionButton
+            action='edit'
+            variant='icon'
+            onClick={() => handleEditMeasurable(row.original)}
+          />
+          <ArchiveToggle outputType='output_indicator' data={row.original} />
+        </div>
+      ) : null
     ),
   },
 ];

--- a/components/logframe/output-indicators-table-columns.tsx
+++ b/components/logframe/output-indicators-table-columns.tsx
@@ -72,7 +72,7 @@ export const createColumns = (
               <ActionButton
                 action='add'
                 label='Add update'
-                className="className='flex w-full items-center justify-center bg-purple-600/20 hover:bg-purple-600/40"
+                className='flex w-full items-center justify-center bg-purple-600/20 hover:bg-purple-600/40'
               />
             </DialogTrigger>
             <DialogContent>

--- a/components/logframe/output-indicators-table.tsx
+++ b/components/logframe/output-indicators-table.tsx
@@ -28,13 +28,15 @@ export default function OutputIndicatorsDetailsTable({
   projectId,
   outputCode,
   showAddButton = true,
-}: {
+  canEditStructure = true,
+}: Readonly<{
   measurables: OutputMeasurable[];
   outputId: number;
   projectId: number;
   outputCode: string;
   showAddButton?: boolean;
-}) {
+  canEditStructure?: boolean;
+}>) {
   const [isMeasurableDialogOpen, setIsMeasurableDialogOpen] = useState(false);
   const [selectedMeasurable, setSelectedMeasurable] =
     useState<OutputMeasurable | null>(null);
@@ -61,6 +63,7 @@ export default function OutputIndicatorsDetailsTable({
     toggleRow,
     expandedRows,
     handleEditMeasurable,
+    canEditStructure,
     projectId.toString(),
   );
 
@@ -79,14 +82,18 @@ export default function OutputIndicatorsDetailsTable({
     <>
       {measurables.length === 0 ? (
         <div className='flex items-center justify-center rounded-md border border-dashed p-12'>
-          <ActionButton
-            action='add'
-            label='Add output indicator'
-            onClick={() => {
-              setSelectedMeasurable(null);
-              setIsMeasurableDialogOpen(true);
-            }}
-          />
+          {canEditStructure ? (
+            <ActionButton
+              action='add'
+              label='Add output indicator'
+              onClick={() => {
+                setSelectedMeasurable(null);
+                setIsMeasurableDialogOpen(true);
+              }}
+            />
+          ) : (
+            <p className='text-sm text-muted-foreground'>No indicators yet.</p>
+          )}
         </div>
       ) : (
         <div className='flex w-full flex-col items-start gap-6'>
@@ -152,7 +159,7 @@ export default function OutputIndicatorsDetailsTable({
               </TableBody>
             </Table>
           </div>
-          {showAddButton && (
+          {showAddButton && canEditStructure && (
             <div className='flex w-full flex-row items-center justify-start'>
               <ActionButton
                 action='add'
@@ -167,15 +174,17 @@ export default function OutputIndicatorsDetailsTable({
         </div>
       )}
 
-      <OutputMeasurableForm
-        isOpen={isMeasurableDialogOpen}
-        onClose={handleCloseMeasurableDialog}
-        measurable={selectedMeasurable}
-        outputId={outputId}
-        projectId={projectId}
-        existingCodes={measurables.map((m) => m.code)}
-        outputCode={outputCode}
-      />
+      {canEditStructure && (
+        <OutputMeasurableForm
+          isOpen={isMeasurableDialogOpen}
+          onClose={handleCloseMeasurableDialog}
+          measurable={selectedMeasurable}
+          outputId={outputId}
+          projectId={projectId}
+          existingCodes={measurables.map((m) => m.code)}
+          outputCode={outputCode}
+        />
+      )}
     </>
   );
 }

--- a/components/logframe/outputs-container.tsx
+++ b/components/logframe/outputs-container.tsx
@@ -11,10 +11,12 @@ import { isUnplannedOutput } from './isUnplannedOutput';
 export default function OutputsContainer({
   outputs,
   projectId,
-}: {
+  canEdit = false,
+}: Readonly<{
   outputs: Output[];
   projectId: number;
-}) {
+  canEdit?: boolean;
+}>) {
   return (
     <div className='flex flex-col gap-8'>
       {outputs.length > 0 ? (
@@ -55,11 +57,17 @@ export default function OutputsContainer({
           variant='output'
           tooltipText={logframeText.output.description}
         >
-          <AddOutputButton
-            projectId={projectId}
-            output={null}
-            existingCodes={outputs.map((o) => o.code)}
-          />
+          {canEdit ? (
+            <AddOutputButton
+              projectId={projectId}
+              output={null}
+              existingCodes={outputs.map((o) => o.code)}
+            />
+          ) : (
+            <p className='text-sm text-muted-foreground'>
+              No outputs yet.
+            </p>
+          )}
         </FeatureCardTheoryOfChange>
       )}
     </div>

--- a/components/project-metadata/edit-dialogue.tsx
+++ b/components/project-metadata/edit-dialogue.tsx
@@ -4,18 +4,21 @@ import { useState } from 'react';
 import { Dialog, DialogContent, DialogTitle } from '../ui/dialog';
 import { ProjectMetadata } from '@/utils/types';
 import EditForm from './edit-form';
+import { useUser } from '@/components/user/user-provider';
 
 export default function EditDialogue({
   project,
-}: {
+}: Readonly<{
   project: ProjectMetadata;
-}) {
+}>) {
+  const { isPartner } = useUser();
   const [isOpen, setIsOpen] = useState(false);
+
+  if (isPartner) return null;
 
   return (
     <div>
       <button
-        role='button'
         className='flex items-center gap-2 rounded-md border border-dashed px-2 py-1 text-sm text-foreground/80 transition-all hover:border-solid hover:border-foreground/50 hover:text-foreground'
         onClick={() => setIsOpen(true)}
       >

--- a/components/project-metadata/edit-dialogue.tsx
+++ b/components/project-metadata/edit-dialogue.tsx
@@ -11,10 +11,10 @@ export default function EditDialogue({
 }: Readonly<{
   project: ProjectMetadata;
 }>) {
-  const { isPartner } = useUser();
+  const { canEditProjectMetadata } = useUser();
   const [isOpen, setIsOpen] = useState(false);
 
-  if (isPartner) return null;
+  if (!canEditProjectMetadata) return null;
 
   return (
     <div>

--- a/components/project-page/project-nav.tsx
+++ b/components/project-page/project-nav.tsx
@@ -13,7 +13,7 @@ export default function ProjectNavigation({
   slug,
 }: Readonly<{ slug: string }>) {
   const pathname = usePathname();
-  const { isPartner } = useUser();
+  const { hasManagerAccess } = useUser();
 
   const items = [
     {
@@ -28,9 +28,8 @@ export default function ProjectNavigation({
       name: 'Logframe',
       href: `/projects/${slug}/logframe`,
     },
-    ...(isPartner
-      ? []
-      : [
+    ...(hasManagerAccess
+      ? [
           {
             name: 'Updates',
             href: `/projects/${slug}/updates`,
@@ -43,7 +42,8 @@ export default function ProjectNavigation({
             name: 'Archive',
             href: `/projects/${slug}/archive`,
           },
-        ]),
+        ]
+      : []),
   ];
 
   return (

--- a/components/project-page/project-nav.tsx
+++ b/components/project-page/project-nav.tsx
@@ -2,14 +2,18 @@
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import { PlusCircleIcon } from 'lucide-react';
+import { useUser } from '@/components/user/user-provider';
 
 interface NavItem {
   name: string;
   href: string;
 }
 
-export default function ProjectNavigation({ slug }: { slug: string }) {
+export default function ProjectNavigation({
+  slug,
+}: Readonly<{ slug: string }>) {
   const pathname = usePathname();
+  const { isPartner } = useUser();
 
   const items = [
     {
@@ -24,18 +28,22 @@ export default function ProjectNavigation({ slug }: { slug: string }) {
       name: 'Logframe',
       href: `/projects/${slug}/logframe`,
     },
-    {
-      name: 'Updates',
-      href: `/projects/${slug}/updates`,
-    },
-    {
-      name: 'Impact',
-      href: `/projects/${slug}/impact`,
-    },
-    {
-      name: 'Archive',
-      href: `/projects/${slug}/archive`,
-    },
+    ...(isPartner
+      ? []
+      : [
+          {
+            name: 'Updates',
+            href: `/projects/${slug}/updates`,
+          },
+          {
+            name: 'Impact',
+            href: `/projects/${slug}/impact`,
+          },
+          {
+            name: 'Archive',
+            href: `/projects/${slug}/archive`,
+          },
+        ]),
   ];
 
   return (

--- a/components/user/user-provider.tsx
+++ b/components/user/user-provider.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { fetchCurrentUserProfile, type AppUserRole } from '@/api/fetch-current-user-profile';
+import { useQuery } from '@tanstack/react-query';
+import React, { createContext, useContext, useMemo } from 'react';
+
+type UserContextValue = {
+  isLoading: boolean;
+  authUserId: string | null;
+  role: AppUserRole | null;
+  isAdmin: boolean;
+  isPartner: boolean;
+  canEditLogframe: boolean;
+};
+
+const UserContext = createContext<UserContextValue | null>(null);
+
+export function UserProvider({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  const { data, isLoading } = useQuery({
+    queryKey: ['current-user-profile'],
+    queryFn: fetchCurrentUserProfile,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const value = useMemo<UserContextValue>(() => {
+    const role = data?.profile?.role ?? null;
+    const authUserId = data?.authUser?.id ?? null;
+    const isAdmin = role === 'Admin';
+    const isPartner = role === 'Partner';
+
+    return {
+      isLoading,
+      authUserId,
+      role,
+      isAdmin,
+      isPartner,
+      canEditLogframe: !isPartner, // Partners are read-only for logframe structure
+    };
+  }, [data?.authUser?.id, data?.profile?.role, isLoading]);
+
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
+}
+
+export function useUser() {
+  const ctx = useContext(UserContext);
+  if (!ctx) {
+    throw new Error('useUser must be used within UserProvider');
+  }
+  return ctx;
+}
+

--- a/components/user/user-provider.tsx
+++ b/components/user/user-provider.tsx
@@ -1,53 +1,68 @@
 'use client';
 
 import { fetchCurrentUserProfile, type AppUserRole } from '@/api/fetch-current-user-profile';
-import { useQuery } from '@tanstack/react-query';
-import React, { createContext, useContext, useMemo } from 'react';
+import { createClient as createSupabaseClient } from '@/utils/supabase/client';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useMemo } from 'react';
 
-type UserContextValue = {
+type UserState = {
   isLoading: boolean;
   authUserId: string | null;
   role: AppUserRole | null;
   isAdmin: boolean;
+  isProjectManager: boolean;
   isPartner: boolean;
+  hasManagerAccess: boolean;
   canEditLogframe: boolean;
+  canEditProjectMetadata: boolean;
 };
 
-const UserContext = createContext<UserContextValue | null>(null);
+const CURRENT_USER_PROFILE_QUERY_KEY = ['current-user-profile'] as const;
 
-export function UserProvider({
-  children,
-}: Readonly<{ children: React.ReactNode }>) {
+export function UserSessionSync() {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const supabase = createSupabaseClient();
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange(() => {
+      void queryClient.resetQueries({ queryKey: CURRENT_USER_PROFILE_QUERY_KEY });
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [queryClient]);
+
+  return null;
+}
+
+export function useUser(): UserState {
   const { data, isLoading } = useQuery({
-    queryKey: ['current-user-profile'],
+    queryKey: CURRENT_USER_PROFILE_QUERY_KEY,
     queryFn: fetchCurrentUserProfile,
     staleTime: 5 * 60 * 1000,
   });
 
-  const value = useMemo<UserContextValue>(() => {
+  return useMemo<UserState>(() => {
     const role = data?.profile?.role ?? null;
     const authUserId = data?.authUser?.id ?? null;
     const isAdmin = role === 'Admin';
+    const isProjectManager = role === 'Project Manager';
     const isPartner = role === 'Partner';
+    const hasManagerAccess = isAdmin || isProjectManager;
 
     return {
       isLoading,
       authUserId,
       role,
       isAdmin,
+      isProjectManager,
       isPartner,
-      canEditLogframe: !isPartner, // Partners are read-only for logframe structure
+      hasManagerAccess,
+      canEditLogframe: hasManagerAccess,
+      canEditProjectMetadata: hasManagerAccess,
     };
   }, [data?.authUser?.id, data?.profile?.role, isLoading]);
-
-  return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
 }
-
-export function useUser() {
-  const ctx = useContext(UserContext);
-  if (!ctx) {
-    throw new Error('useUser must be used within UserProvider');
-  }
-  return ctx;
-}
-

--- a/utils/auth/guards.ts
+++ b/utils/auth/guards.ts
@@ -1,0 +1,17 @@
+'use server';
+
+import { fetchCurrentUserProfile } from '@/api/fetch-current-user-profile';
+import { redirect } from 'next/navigation';
+
+export async function requireNonPartner(redirectTo: string = '/projects') {
+  const data = await fetchCurrentUserProfile();
+
+  // If there's no DB profile, treat as unauthorized for restricted pages.
+  const role = data.profile?.role ?? null;
+  if (role === 'Partner' || role === null) {
+    redirect(redirectTo);
+  }
+
+  return data.profile;
+}
+

--- a/utils/auth/guards.ts
+++ b/utils/auth/guards.ts
@@ -3,12 +3,17 @@
 import { fetchCurrentUserProfile } from '@/api/fetch-current-user-profile';
 import { redirect } from 'next/navigation';
 
-export async function requireNonPartner(redirectTo: string = '/projects') {
+export async function requireNonPartner(
+  redirectTo: string = '/projects',
+  noProfileRedirectTo: string = '/sign-in'
+) {
   const data = await fetchCurrentUserProfile();
 
-  // If there's no DB profile, treat as unauthorized for restricted pages.
-  const role = data.profile?.role ?? null;
-  if (role === 'Partner' || role === null) {
+  if (!data.profile || data.profile.role === null) {
+    redirect(noProfileRedirectTo);
+  }
+
+  if (data.profile.role === 'Partner') {
     redirect(redirectTo);
   }
 


### PR DESCRIPTION
## Summary
A new user type called **Partner** is now available for external project partners. Partners can see only the projects assigned to them, access the Theory of Change and Logframe pages for those projects, and submit updates. They cannot access admin/analytics areas, and they are not allowed to edit logframe structure.

## App changes

### User role and permissions
- Added `fetchCurrentUserProfile()` server action to load `public.users.role`.
- Reworked user-role access to use TanStack Query directly via `useUser()` (no dedicated React user context wrapper).
- Added `UserSessionSync` in `app/layout.tsx` to reset the `current-user-profile` query on auth state changes.
- Exposed role/capability flags from `useUser()`:
  - `isPartner`, `isAdmin`, `isProjectManager`
  - `hasManagerAccess`
  - `canEditLogframe`
  - `canEditProjectMetadata`
- Permission model is fail-closed for structure editing: only Admin/Project Manager can edit logframe structure and project metadata.

### Navigation gating
- Global nav hides **Overview / Impact Indicators / Updates** for non-manager users (including Partners).
- Project nav hides **Updates / Impact / Archive** for non-manager users.
- Project nav still shows **Project Home / Theory of Change / Logframe / Add update**.

### Read-only logframe structure for Partners
- ToC/Logframe pages disable structure-editing actions for Partners (impact/outcomes/outputs/indicators/activities/archive).
- Partners can still add updates via existing update dialogs / add-update page.
- Partners can edit only their own updates; admins can edit all.

### Server-side route guards
- Added server layout guards to redirect Partners away from restricted routes to `/projects` (including direct URL entry).
- Restricted areas include: `/admin`, `/updates`, `/impactindicators`, and project subpages `/updates`, `/impact`, `/archive`.

### UI polish
- Hid Project Metadata **Edit** dialog for users without metadata edit capability (including Partners).

### Build verification
- `pnpm build` passes.

## Supabase changes (RLS + role setup)

### Role
- Added/used `public.users.role = 'Partner'` for partner users.

### Project assignment
- Assigned partner users to projects via `public.user_projects` (one row per `(user_id, project_id)`).

### RLS policies
- Logframe tables (`impacts`, `outcomes`, `outputs`, `outcome_measurables`, `output_measurables`, `activities`):
- Admin/Project Manager: full access.
- Partner: `SELECT` only for assigned projects.
- Projects table:
- Admin/Project Manager: full access.
- Partner: `SELECT` only for assigned projects.
- Updates table:
- Admin/Project Manager: full access.
- Partner: `SELECT` on assigned projects, `INSERT` only when `posted_by = auth.uid()`, `UPDATE` only on own updates.
- Removed broad `ALL` policies on `user_projects` that previously granted unintended Partner write access.

## Testing notes
- Log in as a Partner user assigned to exactly one project.
- `/projects` shows only that project.
- Can open `/projects/[slug]/theory-of-change` and `/projects/[slug]/logframe`.
- Can submit an update.
- Cannot access `/admin`, `/updates`, `/impactindicators`, or project subpages `/updates`, `/impact`, `/archive`.
- No project/logframe structure edit buttons are shown; writes are blocked by RLS if attempted.